### PR TITLE
Update for latest nightly

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -25,8 +25,8 @@ impl<'a> MapBuilder<'a> {
     /// ```rust
     /// use mustache::MapBuilder;
     /// let data = MapBuilder::new()
-    ///     .insert("name", &("Jane Austen")).unwrap()
-    ///     .insert("age", &41u).unwrap()
+    ///     .insert("name", &("Jane Austen")).ok().unwrap()
+    ///     .insert("age", &41u).ok().unwrap()
     ///     .build();
     /// ```
     #[inline]
@@ -163,8 +163,8 @@ impl<'a> VecBuilder<'a> {
     /// ```rust
     /// use mustache::{VecBuilder, Data};
     /// let data: Data = VecBuilder::new()
-    ///     .push(& &"Jane Austen").unwrap()
-    ///     .push(&41u).unwrap()
+    ///     .push(& &"Jane Austen").ok().unwrap()
+    ///     .push(&41u).ok().unwrap()
     ///     .build();
     /// ```
     #[inline]
@@ -317,7 +317,7 @@ mod tests {
             MapBuilder::new()
                 .insert_str("first_name", "Jane")
                 .insert_str("last_name", "Austen")
-                .insert("age", &41us).unwrap()
+                .insert("age", &41us).ok().unwrap()
                 .insert_bool("died", true)
                 .insert_vec("works", |builder| {
                     builder
@@ -325,7 +325,7 @@ mod tests {
                         .push_map(|builder| {
                             builder
                                 .insert_str("title", "Pride and Prejudice")
-                                .insert("publish_date", &1813us).unwrap()
+                                .insert("publish_date", &1813us).ok().unwrap()
                         })
                 })
                 .build(),

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -26,7 +26,7 @@ pub enum Error {
     IoError(StdIoError),
 }
 
-impl fmt::Show for Error {
+impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             UnsupportedType => "unsupported type".fmt(f),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl<'a> PartialEq for Data<'a> {
     }
 }
 
-impl<'a> fmt::Show for Data<'a> {
+impl<'a> fmt::Debug for Data<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             StrVal(ref v) => write!(f, "StrVal({})", v),
@@ -72,7 +72,7 @@ pub struct Context {
     pub template_extension: String,
 }
 
-impl fmt::Show for Context {
+impl fmt::Debug for Context {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Context {{ template_path: {}, template_extension: {} }}",
                self.template_path.display(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -285,7 +285,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
 
                 // Trim the whitespace from the last token.
                 self.tokens.pop();
-                self.tokens.push(Text(s.as_slice().slice(0, pos).to_string()));
+                self.tokens.push(Text(s.as_slice()[0..pos].to_string()));
 
                 true
             }
@@ -309,7 +309,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
                 self.eat_whitespace();
             }
             '&' => {
-                let name = content.slice(1, len);
+                let name = &content[1..len];
                 let name = self.check_content(name);
                 let name = name.as_slice().split_terminator('.')
                     .map(|x| x.to_string())
@@ -318,7 +318,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
             }
             '{' => {
                 if content.ends_with("}") {
-                    let name = content.slice(1, len - 1);
+                    let name = &content[1..len - 1];
                     let name = self.check_content(name);
                     let name = name.as_slice().split_terminator('.')
                         .map(|x| x.to_string())
@@ -329,7 +329,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
             '#' => {
                 let newlined = self.eat_whitespace();
 
-                let name = self.check_content(content.slice(1, len));
+                let name = self.check_content(&content[1..len]);
                 let name = name.as_slice().split_terminator('.')
                     .map(|x| x.to_string())
                     .collect();
@@ -338,7 +338,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
             '^' => {
                 let newlined = self.eat_whitespace();
 
-                let name = self.check_content(content.slice(1, len));
+                let name = self.check_content(&content[1..len]);
                 let name = name.as_slice().split_terminator('.')
                     .map(|x| x.to_string())
                     .collect();
@@ -347,7 +347,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
             '/' => {
                 self.eat_whitespace();
 
-                let name = self.check_content(content.slice(1, len));
+                let name = self.check_content(&content[1..len]);
                 let name = name.as_slice().split_terminator('.')
                     .map(|x| x.to_string())
                     .collect();
@@ -419,7 +419,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
                 self.eat_whitespace();
 
                 if len > 2us && content.ends_with("=") {
-                    let s = self.check_content(content.slice(1, len - 1));
+                    let s = self.check_content(&content[1..len - 1]);
 
                     fn is_whitespace(c: char) -> bool { c.is_whitespace() }
                     let pos = s.as_slice().find(is_whitespace);
@@ -428,17 +428,17 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
                       Some(pos) => { pos }
                     };
 
-                    self.otag = s.as_slice().slice(0, pos).to_string();
+                    self.otag = s.as_slice()[0..pos].to_string();
                     self.otag_chars = self.otag.as_slice().chars().collect();
 
-                    let s2 = s.as_slice().slice_from(pos);
+                    let s2 = &s.as_slice()[pos..];
                     let pos = s2.find(|&: c : char| !c.is_whitespace());
                     let pos = match pos {
                       None => { panic!("invalid change delimiter tag content"); }
                       Some(pos) => { pos }
                     };
 
-                    self.ctag = s2.slice_from(pos).to_string();
+                    self.ctag = s2[pos..].to_string();
                     self.ctag_chars = self.ctag.as_slice().chars().collect();
                 } else {
                     panic!("invalid change delimiter tag content");
@@ -473,11 +473,11 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
                 if self.ch_is('\r') { self.bump(); }
                 self.bump();
 
-                let ws = s.as_slice().slice(pos, s.len());
+                let ws = &s.as_slice()[pos..];
 
                 // Trim the whitespace from the last token.
                 self.tokens.pop();
-                self.tokens.push(Text(s.as_slice().slice(0, pos).to_string()));
+                self.tokens.push(Text(s.as_slice()[0..pos].to_string()));
 
                 ws.to_string()
             }
@@ -486,7 +486,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
         // We can't inline the tokens directly as we may have a recursive
         // partial. So instead, we'll cache the partials we used and look them
         // up later.
-        let name = content.slice(1, content.len());
+        let name = &content[1..content.len()];
         let name = self.check_content(name);
 
         self.tokens.push(Partial(name.to_string(), indent, tag));

--- a/src/template.rs
+++ b/src/template.rs
@@ -127,7 +127,7 @@ impl<'a> RenderContext<'a> {
             let len = value.len();
 
             while pos < len {
-                let v = value.slice_from(pos);
+                let v = &value[pos..];
                 let line = match v.find('\n') {
                     None => {
                         let line = v;
@@ -135,7 +135,7 @@ impl<'a> RenderContext<'a> {
                         line
                     }
                     Some(i) => {
-                        let line = v.slice_to(i + 1);
+                        let line = &v[..i + 1];
                         pos += i + 1;
                         line
                     }
@@ -328,7 +328,7 @@ impl<'a> RenderContext<'a> {
             None => { return None; }
         };
 
-        for part in path.slice_from(1).iter() {
+        for part in path[1..].iter() {
             match *value {
                 Map(ref m) => {
                     match m.get(part) {
@@ -465,6 +465,7 @@ mod tests {
     fn test_render_partial() {
         let template = Context::new(Path::new("src/test-data"))
             .compile_path(Path::new("base"))
+            .ok()
             .unwrap();
 
         let ctx = HashMap::new();
@@ -598,7 +599,7 @@ mod tests {
             };
 
             let mut encoder = Encoder::new();
-            data.encode(&mut encoder).unwrap();
+            data.encode(&mut encoder).ok().unwrap();
             assert_eq!(encoder.data.len(), 1);
 
             run_test(test, encoder.data.pop().unwrap());
@@ -655,7 +656,7 @@ mod tests {
             };
 
             let mut encoder = Encoder::new();
-            data.encode(&mut encoder).unwrap();
+            data.encode(&mut encoder).ok().unwrap();
 
             let mut ctx = match encoder.data.pop().unwrap() {
                 Map(ctx) => ctx,


### PR DESCRIPTION
Changes:
* use [a..b] instead of slice_* methods
* don't why, but unwrap() on Result<>s complains, while
  calling .ok().unwrap() works.

All tests pass.

Signed-off-by: Raul Gutierrez S <rgs@itevenworks.net>