### PR TITLE
Fixed lnk

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cargo test
 
 [1]: http://code.google.com/p/google-ctemplate/
 [2]: http://www.ivan.fomichev.name/2008/05/erlang-template-engine-prototype.html
-[3]: http://defunkt.github.com/mustache/
+[3]: https://mustache.github.io/
 [4]: http://mustache.github.com/mustache.5.html
 [5]: http://docs.nickel.rs/rust-mustache/mustache/index.html
 


### PR DESCRIPTION
Appears http://defunkt.github.com/mustache/ is now https://mustache.github.io/