### PR TITLE
feat(template): allow Option<T> in template data

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -18,6 +18,7 @@ impl Encoder {
 }
 
 pub enum Error {
+    NestedOptions,
     UnsupportedType,
     InvalidStr,
     MissingElements,
@@ -29,6 +30,7 @@ pub enum Error {
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            NestedOptions => "nested Option types are not supported".fmt(f),
             UnsupportedType => "unsupported type".fmt(f),
             InvalidStr => "invalid str".fmt(f),
             MissingElements => "no elements in value".fmt(f),
@@ -181,6 +183,7 @@ impl rustc_serialize::Encoder for Encoder {
   where F : FnOnce(&mut Encoder) -> EncoderResult {
         try!(f(self));
         let val = match self.data.pop() {
+            Some(OptVal(_)) => { return Err(NestedOptions) },
             Some(d) => d,
             _ => { return Err(UnsupportedType); }
         };

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -4,7 +4,7 @@ use std::io::Error as StdIoError;
 use std::iter::repeat;
 use rustc_serialize;
 
-use super::{Data, StrVal, Bool, VecVal, Map};
+use super::{Data, StrVal, Bool, VecVal, Map, OptVal};
 pub use self::Error::*;
 
 pub struct Encoder {
@@ -167,18 +167,25 @@ impl rustc_serialize::Encoder for Encoder {
     }
 
     // Specialized types:
-    fn emit_option< F >(&mut self, _f: F) -> EncoderResult
+    fn emit_option< F >(&mut self, f: F) -> EncoderResult
     where F : FnOnce(&mut Encoder) -> EncoderResult  {
-        Err(UnsupportedType)
+        f(self)
     }
 
     fn emit_option_none(&mut self) -> EncoderResult {
-        Err(UnsupportedType)
+        self.data.push(OptVal(None));
+        Ok(())
     }
 
-    fn emit_option_some< F >(&mut self, _f: F) -> EncoderResult
+    fn emit_option_some< F >(&mut self, f: F) -> EncoderResult
   where F : FnOnce(&mut Encoder) -> EncoderResult {
-        Err(UnsupportedType)
+        try!(f(self));
+        let val = match self.data.pop() {
+            Some(d) => d,
+            _ => { return Err(UnsupportedType); }
+        };
+        self.data.push(OptVal(Some(Box::new(val))));
+        Ok(())
     }
 
     fn emit_seq< F >(&mut self, _len: usize, f: F) -> EncoderResult

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod parser;
 mod template;
 
 pub enum Data {
+    OptVal(Option<Box<Data>>),
     StrVal(String),
     Bool(bool),
     VecVal(Vec<Data>),
@@ -42,6 +43,7 @@ impl<'a> PartialEq for Data {
     #[inline]
     fn eq(&self, other: &Data) -> bool {
         match (self, other) {
+            (&OptVal(ref v0), &OptVal(ref v1)) => v0 == v1,
             (&StrVal(ref v0), &StrVal(ref v1)) => v0 == v1,
             (&Bool(ref v0), &Bool(ref v1)) => v0 == v1,
             (&VecVal(ref v0), &VecVal(ref v1)) => v0 == v1,
@@ -55,6 +57,7 @@ impl<'a> PartialEq for Data {
 impl<'a> fmt::Debug for Data {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            OptVal(ref v) => write!(f, "OptVal({:?})", v),
             StrVal(ref v) => write!(f, "StrVal({})", v),
             Bool(v) => write!(f, "Bool({:?})", v),
             VecVal(ref v) => write!(f, "VecVal({:?})", v),

--- a/src/template.rs
+++ b/src/template.rs
@@ -457,6 +457,23 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(message="nested Option types are not supported")]
+    fn test_render_option_nested() {
+        #[derive(RustcEncodable)]
+        struct Nested { opt: Option<Option<u32>> }
+
+        let template = "-{{opt}}+";
+        let ctx = Nested { opt: None };
+        assert_eq!(&*render(template, &ctx).unwrap(), "-+");
+
+        let ctx = Nested { opt: Some(None) };
+        assert_eq!(&*render(template, &ctx).unwrap(), "-+");
+
+        let ctx = Nested { opt: Some(Some(42)) };
+        assert_eq!(&*render(template, &ctx).unwrap(), "-42+");
+    }
+
+    #[test]
     fn test_render_option_complex() {
         let template = "{{name}} - \
                         {{#info}}{{description}}; \

--- a/src/template.rs
+++ b/src/template.rs
@@ -10,7 +10,7 @@ use parser::Token;
 use parser::Token::*;
 use encoder::Error;
 
-use super::{Context, Data, Bool, StrVal, VecVal, Map, Fun};
+use super::{Context, Data, Bool, StrVal, VecVal, Map, Fun, OptVal};
 
 /// `Template` represents a compiled mustache file.
 #[derive(Debug, Clone)]
@@ -182,8 +182,19 @@ impl<'a> RenderContext<'a> {
     ) {
         match self.find(path, stack) {
             None => { }
-            Some(value) => {
+            Some(mut value) => {
                 wr.write_all(self.indent.as_bytes()).unwrap();
+
+                // Currently this doesn't allow Option<Option<Foo>>, which
+                // would be un-nameable in the view anyway, so I'm unsure if it's
+                // a real problem. Having {{foo}} render only when `foo = Some(Some(val))`
+                // seems unintuitive and may be surprising in practice.
+                if let OptVal(ref inner) = *value {
+                    match *inner {
+                        Some(ref inner) => value = inner,
+                        None => return
+                    }
+                }
 
                 match *value {
                     StrVal(ref value) => {
@@ -214,6 +225,7 @@ impl<'a> RenderContext<'a> {
             None => { }
             Some(&Bool(false)) => { }
             Some(&VecVal(ref xs)) if xs.is_empty() => { }
+            Some(&OptVal(ref val)) if val.is_none() => { }
             Some(_) => { return; }
         }
 
@@ -254,6 +266,16 @@ impl<'a> RenderContext<'a> {
                         let f = &mut *fcell.borrow_mut();
                         let tokens = self.render_fun(src, otag, ctag, f);
                         self.render(wr, stack, &tokens)
+                    },
+                    OptVal(ref val) => {
+                        match *val {
+                            Some(ref val) => {
+                                stack.push(val);
+                                self.render(wr, stack, children);
+                                stack.pop();
+                            }
+                            None => {}
+                        }
                     }
                     _ => { panic!("unexpected value {:?}", value) }
                 }
@@ -361,7 +383,17 @@ mod tests {
     use super::super::{Context, Template};
 
     #[derive(RustcEncodable)]
-    struct Name { name: String }
+    struct Planet { name: String, info: Option<PlanetInfo> }
+
+    #[derive(RustcEncodable)]
+    struct PlanetInfo {
+        moons: Vec<String>,
+        population: u64,
+        description: String
+    }
+
+    #[derive(RustcEncodable)]
+    struct Person { name: String, age: Option<u32> }
 
     fn render<'a, 'b, T: Encodable>(
         template: &str,
@@ -377,7 +409,7 @@ mod tests {
 
     #[test]
     fn test_render_texts() {
-        let ctx = Name { name: "world".to_string() };
+        let ctx = Planet { name: "world".to_string(), info: None };
 
         assert_eq!(&*render("hello world", &ctx).unwrap(), "hello world");
         assert_eq!(&*render("hello {world", &ctx).unwrap(), "hello {world");
@@ -388,16 +420,61 @@ mod tests {
 
     #[test]
     fn test_render_etags() {
-        let ctx = Name { name: "world".to_string() };
+        let ctx = Planet { name: "world".to_string(), info: None };
 
         assert_eq!(&*render("hello {{name}}", &ctx).unwrap(), "hello world");
     }
 
     #[test]
     fn test_render_utags() {
-        let ctx = Name { name: "world".to_string() };
+        let ctx = Planet { name: "world".to_string(), info: None };
 
         assert_eq!(&*render("hello {{{name}}}", &ctx).unwrap(), "hello world");
+
+        assert_eq!(&*render("hello {{{name}}}", &ctx).unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_render_option() {
+        let template = "{{name}}, {{age}}";
+        let ctx = Person { name: "Dennis".to_string(), age: None };
+
+        assert_eq!(&*render(template, &ctx).unwrap(), "Dennis, ");
+
+        let ctx = Person { name: "Dennis".to_string(), age: Some(42) };
+        assert_eq!(&*render(template, &ctx).unwrap(), "Dennis, 42");
+    }
+
+    #[test]
+    fn test_render_option_sections_implicit() {
+        let template = "{{name}}, {{#age}}{{.}}{{/age}}{{^age}}No age{{/age}}";
+        let ctx = Person { name: "Dennis".to_string(), age: None };
+
+        assert_eq!(&*render(template, &ctx).unwrap(), "Dennis, No age");
+
+        let ctx = Person { name: "Dennis".to_string(), age: Some(42) };
+        assert_eq!(&*render(template, &ctx).unwrap(), "Dennis, 42");
+    }
+
+    #[test]
+    fn test_render_option_complex() {
+        let template = "{{name}} - \
+                        {{#info}}{{description}}; \
+                        It's moons are [{{#moons}}{{.}}{{/moons}}] \
+                        and has a population of {{population}}{{/info}}\
+                        {{^info}}No additional info{{/info}}";
+        let ctx = Planet { name: "Jupiter".to_string(), info: None };
+        assert_eq!(&*render(template, &ctx).unwrap(), "Jupiter - No additional info");
+
+        let address = PlanetInfo {
+            moons: vec!["Luna".to_string()],
+            population: 7300000000,
+            description: "Birthplace of rust-lang".to_string(),
+        };
+        let ctx = Planet { name: "Earth".to_string(), info: Some(address) };
+        assert_eq!(&*render(template, &ctx).unwrap(),
+                   "Earth - Birthplace of rust-lang; It's moons are [Luna] and \
+                   has a population of 7300000000");
     }
 
     fn render_data(template: &Template, data: &Data) -> String {


### PR DESCRIPTION
This comes with a restriction that you can't use `Option<Option<T>>` as this is essentially unusable in the view. The commit message gives an example for a workaround.

r? @cburgdorf - You may want to check the tests

Closes #20 