### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,6 +8,7 @@ use encoder::Error;
 use super::{Data, StrVal, Bool, VecVal, Map, Fun};
 
 /// `MapBuilder` is a helper type that construct `Data` types.
+#[derive(Default)]
 pub struct MapBuilder {
     data: HashMap<String, Data>,
 }
@@ -16,9 +17,7 @@ impl MapBuilder {
     /// Create a `MapBuilder`
     #[inline]
     pub fn new() -> MapBuilder {
-        MapBuilder {
-            data: HashMap::new(),
-        }
+        MapBuilder::default()
     }
 
     /// Add an `Encodable` to the `MapBuilder`.
@@ -146,6 +145,7 @@ impl MapBuilder {
     }
 }
 
+#[derive(Default)]
 pub struct VecBuilder {
     data: Vec<Data>,
 }
@@ -154,9 +154,7 @@ impl<'a> VecBuilder {
     /// Create a `VecBuilder`
     #[inline]
     pub fn new() -> VecBuilder {
-        VecBuilder {
-            data: Vec::new(),
-        }
+        VecBuilder::default()
     }
 
     /// Add an `Encodable` to the `VecBuilder`.

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -8,13 +8,14 @@ use rustc_serialize;
 use super::{Data, StrVal, Bool, VecVal, Map, OptVal};
 pub use self::Error::*;
 
+#[derive(Default)]
 pub struct Encoder {
     pub data: Vec<Data>,
 }
 
 impl Encoder {
     pub fn new() -> Encoder {
-        Encoder { data: Vec::new() }
+        Encoder::default()
     }
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -263,7 +263,7 @@ impl rustc_serialize::Encoder for Encoder {
     }
 }
 
-pub fn encode<'a, T: rustc_serialize::Encodable>(data: &T) -> Result<Data, Error> {
+pub fn encode<T: rustc_serialize::Encodable>(data: &T) -> Result<Data, Error> {
     let mut encoder = Encoder::new();
     try!(data.encode(&mut encoder));
     assert_eq!(encoder.data.len(), 1);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -355,7 +355,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
                 let mut children: Vec<Token> = Vec::new();
 
                 loop {
-                    if self.tokens.len() == 0 {
+                    if self.tokens.is_empty() {
                         panic!("closing unopened section");
                     }
 
@@ -514,7 +514,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
 
     fn check_content(&self, content: &str) -> String {
         let trimmed = content.trim();
-        if trimmed.len() == 0 {
+        if trimmed.is_empty() {
             panic!("empty tag");
         }
         trimmed.to_string()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -304,7 +304,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
                 self.tokens.push(UTag(name, tag));
             }
             '{' => {
-                if content.ends_with("}") {
+                if content.ends_with('}') {
                     let name = &content[1..len - 1];
                     let name = self.check_content(name);
                     let name = name.split_terminator('.')
@@ -402,7 +402,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
             '=' => {
                 self.eat_whitespace();
 
-                if len > 2usize && content.ends_with("=") {
+                if len > 2usize && content.ends_with('=') {
                     let s = self.check_content(&content[1..len - 1]);
 
                     fn is_whitespace(c: char) -> bool { c.is_whitespace() }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -405,8 +405,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
                 if len > 2usize && content.ends_with('=') {
                     let s = self.check_content(&content[1..len - 1]);
 
-                    fn is_whitespace(c: char) -> bool { c.is_whitespace() }
-                    let pos = s.find(is_whitespace);
+                    let pos = s.find(char::is_whitespace);
                     let pos = match pos {
                       None => { panic!("invalid change delimiter tag content"); }
                       Some(pos) => { pos }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -106,12 +106,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
     pub fn parse(mut self) -> (Vec<Token>, Vec<String>) {
         let mut curly_brace_tag = false;
 
-        loop {
-            let ch = match self.ch {
-                Some(ch) => ch,
-                None => { break; }
-            };
-
+        while let Some(ch) = self.ch {
             match self.state {
                 TEXT => {
                     if ch == self.otag_chars[0] {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -72,16 +72,13 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
             Some(ch) => { self.ch = Some(ch); }
         }
 
-        match self.ch {
-            Some(ch) => {
-                if ch == '\n' {
-                    self.line += 1;
-                    self.col = 1;
-                } else {
-                    self.col += 1;
-                }
+        if let Some(ch) = self.ch {
+            if ch == '\n' {
+                self.line += 1;
+                self.col = 1;
+            } else {
+                self.col += 1;
             }
-            None => { }
         }
     }
 
@@ -192,13 +189,10 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
 
         // Check that we don't have any incomplete sections.
         for token in self.tokens.iter() {
-            match *token {
-                IncompleteSection(ref path, _, _, _) => {
-                    panic!("Unclosed mustache section {}", path.join("."));
-              }
-              _ => {}
+            if let IncompleteSection(ref path, _, _, _) = *token {
+                panic!("Unclosed mustache section {}", path.join("."));
             }
-        };
+        }
 
         let Parser { tokens, partials, .. } = self;
 
@@ -221,12 +215,9 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
     //
     fn classify_token(&mut self) -> TokenClass {
         // Exit early if the next character is not '\n' or '\r\n'.
-        match self.ch {
-            None => { }
-            Some(ch) => {
-                if !(ch == '\n' || (ch == '\r' && self.peek() == Some('\n'))) {
-                    return Normal;
-                }
+        if let Some(ch) = self.ch {
+            if !(ch == '\n' || (ch == '\r' && self.peek() == Some('\n'))) {
+                return Normal;
             }
         }
 
@@ -402,11 +393,8 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
                                 panic!("Unclosed section");
                             }
                         }
-                        _ => { match last {
-                            Some(last_token) => {children.push(last_token); }
-                            None => ()
-                            }
-                        }
+                        Some(last_token) => children.push(last_token),
+                        None => (),
                     }
                 }
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -204,7 +204,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
             let mut content = String::new();
             mem::swap(&mut content, &mut self.content);
 
-            self.tokens.push(Text(content.to_string()));
+            self.tokens.push(Text(content));
         }
     }
 
@@ -235,7 +235,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
                     // It's all whitespace.
                     None => {
                         if self.tokens.len() == 1 {
-                            WhiteSpace(s.to_string(), 0)
+                            WhiteSpace(s.clone(), 0)
                         } else {
                             Normal
                         }
@@ -245,7 +245,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
                             if pos == s.len() - 1 {
                                 StandAlone
                             } else {
-                                WhiteSpace(s.to_string(), pos + 1)
+                                WhiteSpace(s.clone(), pos + 1)
                             }
                         } else { Normal }
                     }
@@ -383,11 +383,11 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
                                         name,
                                         inverted,
                                         children,
-                                        self.otag.to_string(),
+                                        self.otag.clone(),
                                         osection,
-                                        src.to_string(),
+                                        src,
                                         tag,
-                                        self.ctag.to_string()));
+                                        self.ctag.clone()));
                                 break;
                             } else {
                                 panic!("Unclosed section");
@@ -473,7 +473,7 @@ impl<'a, T: Iterator<Item=char>> Parser<'a, T> {
         let name = &content[1..content.len()];
         let name = self.check_content(name);
 
-        self.tokens.push(Partial(name.to_string(), indent, tag));
+        self.tokens.push(Partial(name.clone(), indent, tag));
         self.partials.push(name);
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -285,13 +285,10 @@ impl<'a> RenderContext<'a> {
                         self.render(wr, stack, &tokens)
                     },
                     OptVal(ref val) => {
-                        match *val {
-                            Some(ref val) => {
-                                stack.push(val);
-                                self.render(wr, stack, children);
-                                stack.pop();
-                            }
-                            None => {}
+                        if let Some(ref val) = *val {
+                            stack.push(val);
+                            self.render(wr, stack, children);
+                            stack.pop();
                         }
                     }
                     _ => { panic!("unexpected value {:?}", value) }
@@ -348,12 +345,9 @@ impl<'a> RenderContext<'a> {
         for data in stack.iter().rev() {
             match **data {
                 Map(ref m) => {
-                    match m.get(&path[0]) {
-                        Some(v) => {
-                            value = Some(v);
-                            break;
-                        }
-                        None => { }
+                    if let Some(v) = m.get(&path[0]) {
+                        value = Some(v);
+                        break;
                     }
                 }
                 _ => { panic!("expect map: {:?}", path) }

--- a/src/template.rs
+++ b/src/template.rs
@@ -33,7 +33,7 @@ Vec<Token>>) -> Template {
 
 impl Template {
     /// Renders the template with the `Encodable` data.
-    pub fn render<'a, W: Write, T: Encodable>(
+    pub fn render<W: Write, T: Encodable>(
         &self,
         wr: &mut W,
         data: &T
@@ -43,7 +43,7 @@ impl Template {
     }
 
     /// Renders the template with the `Data`.
-    pub fn render_data<'a, W: Write>(&self, wr: &mut W, data: &Data) {
+    pub fn render_data<W: Write>(&self, wr: &mut W, data: &Data) {
         let mut render_ctx = RenderContext::new(self);
         let mut stack = vec!(data);
 
@@ -69,7 +69,7 @@ impl<'a> RenderContext<'a> {
         }
     }
 
-    fn render<'b, W: Write>(
+    fn render<W: Write>(
         &mut self,
         wr: &mut W,
         stack: &mut Vec<&Data>,
@@ -80,7 +80,7 @@ impl<'a> RenderContext<'a> {
         }
     }
 
-    fn render_token<'b, W: Write>(
+    fn render_token<W: Write>(
         &mut self,
         wr: &mut W,
         stack: &mut Vec<&Data>,
@@ -167,7 +167,7 @@ impl<'a> RenderContext<'a> {
         }
     }
 
-    fn render_etag<'b, W: Write>(
+    fn render_etag<W: Write>(
         &mut self,
         wr: &mut W,
         stack: &mut Vec<&Data>,
@@ -191,7 +191,7 @@ impl<'a> RenderContext<'a> {
         }
     }
 
-    fn render_utag<'b, W: Write>(
+    fn render_utag<W: Write>(
         &mut self,
         wr: &mut W,
         stack: &mut Vec<&Data>,
@@ -231,7 +231,7 @@ impl<'a> RenderContext<'a> {
         };
     }
 
-    fn render_inverted_section<'b, W: Write>(
+    fn render_inverted_section<W: Write>(
         &mut self,
         wr: &mut W,
         stack: &mut Vec<&Data>,
@@ -249,7 +249,7 @@ impl<'a> RenderContext<'a> {
         self.render(wr, stack, children);
     }
 
-    fn render_section<'b, W: Write>(
+    fn render_section<W: Write>(
         &mut self,
         wr: &mut W,
         stack: &mut Vec<&Data>,
@@ -300,7 +300,7 @@ impl<'a> RenderContext<'a> {
         }
     }
 
-    fn render_partial<'b, W: Write>(
+    fn render_partial<W: Write>(
         &mut self,
         wr: &mut W,
         stack: &mut Vec<&Data>,
@@ -333,7 +333,7 @@ impl<'a> RenderContext<'a> {
         tokens
     }
 
-    fn find<'b, 'c>(&self, path: &[String], stack: &mut Vec<&'c Data>) -> Option<&'c Data> {
+    fn find<'c>(&self, path: &[String], stack: &mut Vec<&'c Data>) -> Option<&'c Data> {
         // If we have an empty path, we just want the top value in our stack.
         if path.is_empty() {
             match stack.last() {


### PR DESCRIPTION
Before:
```
warnings:
	 explicit_iter_loop : 3
	 items_after_statements : 1
	 len_zero : 1
	 map_entry : 1
	 new_without_default : 3
	 or_fun_call : 1
	 panic_params : 1
	 single_char_pattern : 2
	 single_match : 5
	 str_to_string : 29
	 string_to_string : 8
	 unused_lifetimes : 11
	 while_let_loop : 1
```
After:
```
	 explicit_iter_loop : 3 // not fixed because it seems the convention in mustache
	 or_fun_call : 1 // not fixed because it’s kind of a false positive here
	 str_to_string : 29 // not fixed because me lazy, let’s hope specialization will make this irrelevant some day
```