### PR TITLE
fix(panics): return Results instead of runtime panics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - target
 
 rust:
-- 1.3.0
+- 1.4.0
 - stable
 - nightly
 - beta

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ struct Planet {
 
 fn main() {
     // First the string needs to be compiled.
-    let template = mustache::compile_str("hello {{name}}");
+    let template = mustache::compile_str("hello {{name}}").unwrap();
 
     // You can either use an encodable type to print "hello Mercury".
     let planet = Planet { name: "Mercury".into() };
@@ -52,7 +52,7 @@ fn main() {
         .insert_str("name", "Venus")
         .build();
 
-    template.render_data(&mut io::stdout(), &data);
+    template.render_data(&mut io::stdout(), &data).unwrap();
     println!("");
 
     // ... you can even use closures.
@@ -65,15 +65,15 @@ fn main() {
         .build();
 
     // prints "hello Earth"
-    template.render_data(&mut io::stdout(), &data);
+    template.render_data(&mut io::stdout(), &data).unwrap();
     println!("");
 
     // prints "hello Mars"
-    template.render_data(&mut io::stdout(), &data);
+    template.render_data(&mut io::stdout(), &data).unwrap();
     println!("");
 
     // prints "hello Jupiter"
-    template.render_data(&mut io::stdout(), &data);
+    template.render_data(&mut io::stdout(), &data).unwrap();
     println!("");
 }
 ```

--- a/examples/vector_iteration.rs
+++ b/examples/vector_iteration.rs
@@ -25,7 +25,7 @@ fn main() {
     data.insert("users", users);
 
     let mut bytes = vec![];
-    template.render(&mut bytes, &data).unwrap();
+    template.render(&mut bytes, &data).expect("Failed to render");
 
     assert_eq!(str::from_utf8(&bytes), Ok("Hello Harry!\nHello Samantha!\n"))
 }

--- a/examples/vector_iteration.rs
+++ b/examples/vector_iteration.rs
@@ -14,7 +14,7 @@ fn main() {
                    Hello {{name}}!
                    {{/users}}";
 
-    let template = mustache::compile_str(template);
+    let template = mustache::compile_str(template).expect("Failed to compile");
 
     let users = vec![
         User { name: "Harry".into() },

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+write_mode = "Overwrite"
+where_indent = "Inherit"
+take_source_hints = false

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -149,7 +149,7 @@ pub struct VecBuilder {
     data: Vec<Data>,
 }
 
-impl<'a> VecBuilder {
+impl VecBuilder {
     /// Create a `VecBuilder`
     #[inline]
     pub fn new() -> VecBuilder {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -25,8 +25,8 @@ impl MapBuilder {
     /// ```rust
     /// use mustache::MapBuilder;
     /// let data = MapBuilder::new()
-    ///     .insert("name", &("Jane Austen")).ok().unwrap()
-    ///     .insert("age", &41usize).ok().unwrap()
+    ///     .insert("name", &("Jane Austen")).expect("Failed to encode name")
+    ///     .insert("age", &41usize).expect("Failed to encode age")
     ///     .build();
     /// ```
     #[inline]
@@ -161,8 +161,8 @@ impl<'a> VecBuilder {
     /// ```rust
     /// use mustache::{VecBuilder, Data};
     /// let data: Data = VecBuilder::new()
-    ///     .push(& &"Jane Austen").ok().unwrap()
-    ///     .push(&41usize).ok().unwrap()
+    ///     .push(& &"Jane Austen").unwrap()
+    ///     .push(&41usize).unwrap()
     ///     .build();
     /// ```
     #[inline]
@@ -314,16 +314,12 @@ mod tests {
         assert_eq!(MapBuilder::new()
                        .insert_str("first_name", "Jane")
                        .insert_str("last_name", "Austen")
-                       .insert("age", &41usize)
-                       .ok()
-                       .unwrap()
+                       .insert("age", &41usize).expect("age")
                        .insert_bool("died", true)
                        .insert_vec("works", |builder| {
                 builder.push_str("Sense and Sensibility").push_map(|builder| {
                     builder.insert_str("title", "Pride and Prejudice")
-                        .insert("publish_date", &1813usize)
-                        .ok()
-                        .unwrap()
+                        .insert("publish_date", &1813usize).expect("publish_date")
                 })
             })
                        .build(),
@@ -345,8 +341,8 @@ mod tests {
 
         match data {
             Map(m) => {
-                match *m.get(&"count".to_string()).unwrap() {
-                    Fun(ref f) => {
+                match m.get("count") {
+                    Some(&Fun(ref f)) => {
                         let f = &mut *f.borrow_mut();
                         assert_eq!((*f)("count: ".to_string()), "count: 1".to_string());
                         assert_eq!((*f)("count: ".to_string()), "count: 2".to_string());

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -30,9 +30,7 @@ impl MapBuilder {
     ///     .build();
     /// ```
     #[inline]
-    pub fn insert<
-        K: ToString, T: Encodable
-    >(self, key: K, value: &T) -> Result<MapBuilder, Error> {
+    pub fn insert<K: ToString, T: Encodable>(self, key: K, value: &T) -> Result<MapBuilder, Error> {
         let MapBuilder { mut data } = self;
         let value = try!(encoder::encode(value));
         data.insert(key.to_string(), value);
@@ -48,9 +46,7 @@ impl MapBuilder {
     ///     .build();
     /// ```
     #[inline]
-    pub fn insert_str<
-        K: ToString, V: ToString
-    >(self, key: K, value: V) -> MapBuilder {
+    pub fn insert_str<K: ToString, V: ToString>(self, key: K, value: V) -> MapBuilder {
         let MapBuilder { mut data } = self;
         data.insert(key.to_string(), StrVal(value.to_string()));
         MapBuilder { data: data }
@@ -85,7 +81,8 @@ impl MapBuilder {
     /// ```
     #[inline]
     pub fn insert_vec<K: ToString, F>(self, key: K, mut f: F) -> MapBuilder
-        where F: FnMut(VecBuilder) -> VecBuilder {
+    where F: FnMut(VecBuilder) -> VecBuilder
+    {
         let MapBuilder { mut data } = self;
         let builder = f(VecBuilder::new());
         data.insert(key.to_string(), builder.build());
@@ -111,7 +108,8 @@ impl MapBuilder {
     /// ```
     #[inline]
     pub fn insert_map<K: ToString, F>(self, key: K, mut f: F) -> MapBuilder
-        where F: FnMut(MapBuilder) -> MapBuilder {
+    where F: FnMut(MapBuilder) -> MapBuilder
+    {
         let MapBuilder { mut data } = self;
         let builder = f(MapBuilder::new());
         data.insert(key.to_string(), builder.build());
@@ -132,7 +130,8 @@ impl MapBuilder {
     /// ```
     #[inline]
     pub fn insert_fn<K: ToString, F>(self, key: K, f: F) -> MapBuilder
-                                where F: FnMut(String) -> String + Send + 'static {
+    where F: FnMut(String) -> String + Send + 'static
+    {
         let MapBuilder { mut data } = self;
         data.insert(key.to_string(), Fun(RefCell::new(Box::new(f))));
         MapBuilder { data: data }
@@ -220,7 +219,8 @@ impl<'a> VecBuilder {
     /// ```
     #[inline]
     pub fn push_vec<F>(self, mut f: F) -> VecBuilder
-        where F: FnMut(VecBuilder) -> VecBuilder {
+    where F: FnMut(VecBuilder) -> VecBuilder
+    {
         let VecBuilder { mut data } = self;
         let builder = f(VecBuilder::new());
         data.push(builder.build());
@@ -246,7 +246,8 @@ impl<'a> VecBuilder {
     /// ```
     #[inline]
     pub fn push_map<F>(self, mut f: F) -> VecBuilder
-        where F: FnMut(MapBuilder) -> MapBuilder {
+    where F: FnMut(MapBuilder) -> MapBuilder
+    {
         let VecBuilder { mut data } = self;
         let builder = f(MapBuilder::new());
         data.push(builder.build());
@@ -267,7 +268,8 @@ impl<'a> VecBuilder {
     /// ```
     #[inline]
     pub fn push_fn<F>(self, f: F) -> VecBuilder
-                   where F: FnMut(String) -> String + Send + 'static {
+    where F: FnMut(String) -> String + Send + 'static
+    {
         let VecBuilder { mut data } = self;
         data.push(Fun(RefCell::new(Box::new(f))));
         VecBuilder { data: data }
@@ -288,19 +290,16 @@ mod tests {
 
     #[test]
     fn test_empty_builders() {
-        assert_eq!(
-            MapBuilder::new().build(),
-            Map(HashMap::new()));
+        assert_eq!(MapBuilder::new().build(), Map(HashMap::new()));
 
-        assert_eq!(
-            VecBuilder::new().build(),
-            VecVal(Vec::new()));
+        assert_eq!(VecBuilder::new().build(), VecVal(Vec::new()));
     }
 
     #[test]
     fn test_builders() {
         let mut pride_and_prejudice = HashMap::new();
-        pride_and_prejudice.insert("title".to_string(), StrVal("Pride and Prejudice".to_string()));
+        pride_and_prejudice.insert("title".to_string(),
+                                   StrVal("Pride and Prejudice".to_string()));
         pride_and_prejudice.insert("publish_date".to_string(), StrVal("1813".to_string()));
 
         let mut m = HashMap::new();
@@ -308,27 +307,27 @@ mod tests {
         m.insert("last_name".to_string(), StrVal("Austen".to_string()));
         m.insert("age".to_string(), StrVal("41".to_string()));
         m.insert("died".to_string(), Bool(true));
-        m.insert("works".to_string(), VecVal(vec!(
-            StrVal("Sense and Sensibility".to_string()),
-            Map(pride_and_prejudice))));
+        m.insert("works".to_string(),
+                 VecVal(vec![StrVal("Sense and Sensibility".to_string()),
+                             Map(pride_and_prejudice)]));
 
-        assert_eq!(
-            MapBuilder::new()
-                .insert_str("first_name", "Jane")
-                .insert_str("last_name", "Austen")
-                .insert("age", &41usize).ok().unwrap()
-                .insert_bool("died", true)
-                .insert_vec("works", |builder| {
-                    builder
-                        .push_str("Sense and Sensibility")
-                        .push_map(|builder| {
-                            builder
-                                .insert_str("title", "Pride and Prejudice")
-                                .insert("publish_date", &1813usize).ok().unwrap()
-                        })
+        assert_eq!(MapBuilder::new()
+                       .insert_str("first_name", "Jane")
+                       .insert_str("last_name", "Austen")
+                       .insert("age", &41usize)
+                       .ok()
+                       .unwrap()
+                       .insert_bool("died", true)
+                       .insert_vec("works", |builder| {
+                builder.push_str("Sense and Sensibility").push_map(|builder| {
+                    builder.insert_str("title", "Pride and Prejudice")
+                        .insert("publish_date", &1813usize)
+                        .ok()
+                        .unwrap()
                 })
-                .build(),
-            Map(m));
+            })
+                       .build(),
+                   Map(m));
     }
 
     #[test]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -339,20 +339,14 @@ mod tests {
             })
             .build();
 
-        match data {
-            Map(m) => {
-                match m.get("count") {
-                    Some(&Fun(ref f)) => {
-                        let f = &mut *f.borrow_mut();
-                        assert_eq!((*f)("count: ".to_string()), "count: 1".to_string());
-                        assert_eq!((*f)("count: ".to_string()), "count: 2".to_string());
-                        assert_eq!((*f)("count: ".to_string()), "count: 3".to_string());
-                    }
-                    _ => panic!(),
-                }
-            }
-            _ => panic!(),
-        }
+        assert_let!(Map(m) = data => {
+            assert_let!(Some(&Fun(ref f)) = m.get("count") => {
+                let f = &mut *f.borrow_mut();
+                assert_eq!((*f)("count: ".to_string()), "count: 1".to_string());
+                assert_eq!((*f)("count: ".to_string()), "count: 2".to_string());
+                assert_eq!((*f)("count: ".to_string()), "count: 3".to_string());
+            });
+        })
     }
 
     #[test]
@@ -368,24 +362,17 @@ mod tests {
             })
             .build();
 
-        match data {
-            VecVal(vs) => {
-                let mut iter = vs.iter();
+        assert_let!(VecVal(vs) = data => {
+            let mut iter = vs.iter();
 
-                if let Some(&Fun(ref f)) = iter.next() {
-                    let f = &mut *f.borrow_mut();
-                    assert_eq!((*f)("count: ".to_string()), "count: 1".to_string());
-                    assert_eq!((*f)("count: ".to_string()), "count: 2".to_string());
-                    assert_eq!((*f)("count: ".to_string()), "count: 3".to_string());
-                } else {
-                    panic!()
-                }
+            assert_let!(Some(&Fun(ref f)) = iter.next() => {
+                let f = &mut *f.borrow_mut();
+                assert_eq!((*f)("count: ".to_string()), "count: 1".to_string());
+                assert_eq!((*f)("count: ".to_string()), "count: 2".to_string());
+                assert_eq!((*f)("count: ".to_string()), "count: 3".to_string());
+            });
 
-                if let Some(..) = iter.next() {
-                    panic!()
-                }
-            }
-            _ => panic!(),
-        }
+            assert_eq!(iter.next(), None);
+        })
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -161,12 +161,8 @@ mod tests {
         }
     }
 
-    fn check_tokens(_actual: Vec<Token>, _expected: &[Token]) {
-        // TODO: equality is currently broken for enums
-        // let actual: Vec<String> = actual.iter().map(token_to_str).collect();
-        // let expected = expected.iter().map(token_to_str).collect();
-
-        // assert_eq!(actual, expected);
+    fn check_tokens(actual: Vec<Token>, expected: &[Token]) {
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -99,7 +99,7 @@ impl<T: Iterator<Item = char>> Compiler<T> {
 
 #[cfg(test)]
 mod tests {
-    use parser::{Token, Text, ETag, UTag, Section, IncompleteSection, Partial};
+    use parser::{Token, Text, EscapedTag, UnescapedTag, Section, IncompleteSection, Partial};
     use super::Compiler;
     use super::super::Context;
     use std::path::PathBuf;
@@ -135,13 +135,13 @@ mod tests {
                         tag,
                         ctag)
             }
-            ETag(ref name, ref tag) => {
+            EscapedTag(ref name, ref tag) => {
                 let name = name.iter().map(|e| format!("{}", *e)).collect::<Vec<String>>();
-                format!("ETag(vec!({}), {})", name.join(", "), *tag)
+                format!("EscapedTag(vec!({}), {})", name.join(", "), *tag)
             }
-            UTag(ref name, ref tag) => {
+            UnescapedTag(ref name, ref tag) => {
                 let name = name.iter().map(|e| format!("{}", *e)).collect::<Vec<String>>();
-                format!("UTag(vec!({}), {})", name.join(", "), *tag)
+                format!("UnescapedTag(vec!({}), {})", name.join(", "), *tag)
             }
             IncompleteSection(ref name, ref inverted, ref osection, ref newlined) => {
                 let name = name.iter().map(|e| format!("{}", *e)).collect::<Vec<String>>();
@@ -174,38 +174,38 @@ mod tests {
     #[test]
     fn test_compile_etags() {
         check_tokens(compile_str("{{ name }}"),
-                     &[ETag(vec!["name".to_string()], "{{ name }}".to_string())]);
+                     &[EscapedTag(vec!["name".to_string()], "{{ name }}".to_string())]);
 
         check_tokens(compile_str("before {{name}} after"),
                      &[Text("before ".to_string()),
-                       ETag(vec!["name".to_string()], "{{name}}".to_string()),
+                       EscapedTag(vec!["name".to_string()], "{{name}}".to_string()),
                        Text(" after".to_string())]);
 
         check_tokens(compile_str("before {{name}}"),
                      &[Text("before ".to_string()),
-                       ETag(vec!["name".to_string()], "{{name}}".to_string())]);
+                       EscapedTag(vec!["name".to_string()], "{{name}}".to_string())]);
 
         check_tokens(compile_str("{{name}} after"),
-                     &[ETag(vec!["name".to_string()], "{{name}}".to_string()),
+                     &[EscapedTag(vec!["name".to_string()], "{{name}}".to_string()),
                        Text(" after".to_string())]);
     }
 
     #[test]
     fn test_compile_utags() {
         check_tokens(compile_str("{{{name}}}"),
-                     &[UTag(vec!["name".to_string()], "{{{name}}}".to_string())]);
+                     &[UnescapedTag(vec!["name".to_string()], "{{{name}}}".to_string())]);
 
         check_tokens(compile_str("before {{{name}}} after"),
                      &[Text("before ".to_string()),
-                       UTag(vec!["name".to_string()], "{{{name}}}".to_string()),
+                       UnescapedTag(vec!["name".to_string()], "{{{name}}}".to_string()),
                        Text(" after".to_string())]);
 
         check_tokens(compile_str("before {{{name}}}"),
                      &[Text("before ".to_string()),
-                       UTag(vec!["name".to_string()], "{{{name}}}".to_string())]);
+                       UnescapedTag(vec!["name".to_string()], "{{{name}}}".to_string())]);
 
         check_tokens(compile_str("{{{name}}} after"),
-                     &[UTag(vec!["name".to_string()], "{{{name}}}".to_string()),
+                     &[UnescapedTag(vec!["name".to_string()], "{{{name}}}".to_string()),
                        Text(" after".to_string())]);
     }
 
@@ -300,7 +300,7 @@ mod tests {
     fn test_compile_delimiters() {
         check_tokens(compile_str("before {{=<% %>=}}<%name%> after"),
                      &[Text("before ".to_string()),
-                       ETag(vec!["name".to_string()], "<%name%>".to_string()),
+                       EscapedTag(vec!["name".to_string()], "<%name%>".to_string()),
                        Text(" after".to_string())]);
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -51,7 +51,7 @@ impl<T: Iterator<Item = char>> Compiler<T> {
     pub fn compile(mut self) -> Result<(Vec<Token>, PartialsMap)> {
         let (tokens, partials) = {
             let parser = Parser::new(&mut self.reader, &self.otag, &self.ctag);
-            parser.parse()
+            try!(parser.parse())
         };
 
         // Compile the partials if we haven't done so already.

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -3,7 +3,7 @@ use std::io::ErrorKind::NotFound;
 use std::io::Read;
 use std::fs::File;
 
-use parser::{Parser, Token};
+use parser_internals::{Parser, Token};
 use super::Context;
 
 use Result;
@@ -99,7 +99,7 @@ impl<T: Iterator<Item = char>> Compiler<T> {
 
 #[cfg(test)]
 mod tests {
-    use parser::{Token, Text, EscapedTag, UnescapedTag, Section, IncompleteSection, Partial};
+    use parser_internals::{Token, Text, EscapedTag, UnescapedTag, Section, IncompleteSection, Partial};
     use super::Compiler;
     use super::super::Context;
     use std::path::PathBuf;

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -16,7 +16,7 @@ pub struct Compiler<T> {
     ctag: String,
 }
 
-impl<T: Iterator<Item=char>> Compiler<T> {
+impl<T: Iterator<Item = char>> Compiler<T> {
     /// Construct a default compiler.
     pub fn new(ctx: Context, reader: T) -> Compiler<T> {
         Compiler {
@@ -33,7 +33,8 @@ impl<T: Iterator<Item=char>> Compiler<T> {
                     reader: T,
                     partials: HashMap<String, Vec<Token>>,
                     otag: String,
-                    ctag: String) -> Compiler<T> {
+                    ctag: String)
+                    -> Compiler<T> {
         Compiler {
             ctx: ctx,
             reader: reader,
@@ -52,8 +53,8 @@ impl<T: Iterator<Item=char>> Compiler<T> {
 
         // Compile the partials if we haven't done so already.
         for name in partials.into_iter() {
-            let path = self.ctx.template_path
-                               .join(&(name.clone() + "." + &self.ctx.template_extension));
+            let path =
+                self.ctx.template_path.join(&(name.clone() + "." + &self.ctx.template_extension));
 
             if !self.partials.contains_key(&name) {
                 // Insert a placeholder so we don't recurse off to infinity.
@@ -65,7 +66,9 @@ impl<T: Iterator<Item=char>> Compiler<T> {
                         file.read_to_end(&mut contents).unwrap();
                         let string = match str::from_utf8(&contents) {
                             Ok(string) => string.to_string(),
-                            Err(_) => { panic!("Failed to parse file as UTF-8"); }
+                            Err(_) => {
+                                panic!("Failed to parse file as UTF-8");
+                            }
                         };
 
                         let compiler = Compiler {
@@ -83,7 +86,7 @@ impl<T: Iterator<Item=char>> Compiler<T> {
 
                         // Set final compiled tokens for *this* partial
                         self.partials.insert(name, tokens);
-                    },
+                    }
                     Err(e) => {
                         // Ignore missing files.
                         if e.kind() != NotFound {
@@ -152,199 +155,160 @@ mod tests {
                         *osection,
                         *newlined)
             }
-            _ => {
-                format!("{:?}", token)
-            }
+            _ => format!("{:?}", token),
         }
     }
 
     fn check_tokens(_actual: Vec<Token>, _expected: &[Token]) {
         // TODO: equality is currently broken for enums
-        //let actual: Vec<String> = actual.iter().map(token_to_str).collect();
-        //let expected = expected.iter().map(token_to_str).collect();
+        // let actual: Vec<String> = actual.iter().map(token_to_str).collect();
+        // let expected = expected.iter().map(token_to_str).collect();
 
-        //assert_eq!(actual, expected);
+        // assert_eq!(actual, expected);
     }
 
     #[test]
     fn test_compile_texts() {
-        check_tokens(compile_str("hello world"), &[
-            Text("hello world".to_string())
-        ]);
-        check_tokens(compile_str("hello {world"), &[
-            Text("hello {world".to_string())
-        ]);
-        check_tokens(compile_str("hello world}"), &[
-            Text("hello world}".to_string())
-        ]);
-        check_tokens(compile_str("hello world}}"), &[
-            Text("hello world}}".to_string())
-        ]);
+        check_tokens(compile_str("hello world"),
+                     &[Text("hello world".to_string())]);
+        check_tokens(compile_str("hello {world"),
+                     &[Text("hello {world".to_string())]);
+        check_tokens(compile_str("hello world}"),
+                     &[Text("hello world}".to_string())]);
+        check_tokens(compile_str("hello world}}"),
+                     &[Text("hello world}}".to_string())]);
     }
 
     #[test]
     fn test_compile_etags() {
-        check_tokens(compile_str("{{ name }}"), &[
-            ETag(vec!("name".to_string()), "{{ name }}".to_string())
-        ]);
+        check_tokens(compile_str("{{ name }}"),
+                     &[ETag(vec!["name".to_string()], "{{ name }}".to_string())]);
 
-        check_tokens(compile_str("before {{name}} after"), &[
-            Text("before ".to_string()),
-            ETag(vec!("name".to_string()), "{{name}}".to_string()),
-            Text(" after".to_string())
-        ]);
+        check_tokens(compile_str("before {{name}} after"),
+                     &[Text("before ".to_string()),
+                       ETag(vec!["name".to_string()], "{{name}}".to_string()),
+                       Text(" after".to_string())]);
 
-        check_tokens(compile_str("before {{name}}"), &[
-            Text("before ".to_string()),
-            ETag(vec!("name".to_string()), "{{name}}".to_string())
-        ]);
+        check_tokens(compile_str("before {{name}}"),
+                     &[Text("before ".to_string()),
+                       ETag(vec!["name".to_string()], "{{name}}".to_string())]);
 
-        check_tokens(compile_str("{{name}} after"), &[
-            ETag(vec!("name".to_string()), "{{name}}".to_string()),
-            Text(" after".to_string())
-        ]);
+        check_tokens(compile_str("{{name}} after"),
+                     &[ETag(vec!["name".to_string()], "{{name}}".to_string()),
+                       Text(" after".to_string())]);
     }
 
     #[test]
     fn test_compile_utags() {
-        check_tokens(compile_str("{{{name}}}"), &[
-            UTag(vec!("name".to_string()), "{{{name}}}".to_string())
-        ]);
+        check_tokens(compile_str("{{{name}}}"),
+                     &[UTag(vec!["name".to_string()], "{{{name}}}".to_string())]);
 
-        check_tokens(compile_str("before {{{name}}} after"), &[
-            Text("before ".to_string()),
-            UTag(vec!("name".to_string()), "{{{name}}}".to_string()),
-            Text(" after".to_string())
-        ]);
+        check_tokens(compile_str("before {{{name}}} after"),
+                     &[Text("before ".to_string()),
+                       UTag(vec!["name".to_string()], "{{{name}}}".to_string()),
+                       Text(" after".to_string())]);
 
-        check_tokens(compile_str("before {{{name}}}"), &[
-            Text("before ".to_string()),
-            UTag(vec!("name".to_string()), "{{{name}}}".to_string())
-        ]);
+        check_tokens(compile_str("before {{{name}}}"),
+                     &[Text("before ".to_string()),
+                       UTag(vec!["name".to_string()], "{{{name}}}".to_string())]);
 
-        check_tokens(compile_str("{{{name}}} after"), &[
-            UTag(vec!("name".to_string()), "{{{name}}}".to_string()),
-            Text(" after".to_string())
-        ]);
+        check_tokens(compile_str("{{{name}}} after"),
+                     &[UTag(vec!["name".to_string()], "{{{name}}}".to_string()),
+                       Text(" after".to_string())]);
     }
 
     #[test]
     fn test_compile_sections() {
-        check_tokens(compile_str("{{# name}}{{/name}}"), &[
-            Section(
-                vec!("name".to_string()),
-                false,
-                Vec::new(),
-                "{{".to_string(),
-                "{{# name}}".to_string(),
-                "".to_string(),
-                "{{/name}}".to_string(),
-                "}}".to_string()
-            )
-        ]);
+        check_tokens(compile_str("{{# name}}{{/name}}"),
+                     &[Section(vec!["name".to_string()],
+                               false,
+                               Vec::new(),
+                               "{{".to_string(),
+                               "{{# name}}".to_string(),
+                               "".to_string(),
+                               "{{/name}}".to_string(),
+                               "}}".to_string())]);
 
-        check_tokens(compile_str("before {{^name}}{{/name}} after"), &[
-            Text("before ".to_string()),
-            Section(
-                vec!("name".to_string()),
-                true,
-                Vec::new(),
-                "{{".to_string(),
-                "{{^name}}".to_string(),
-                "".to_string(),
-                "{{/name}}".to_string(),
-                "}}".to_string()
-            ),
-            Text(" after".to_string())
-        ]);
+        check_tokens(compile_str("before {{^name}}{{/name}} after"),
+                     &[Text("before ".to_string()),
+                       Section(vec!["name".to_string()],
+                               true,
+                               Vec::new(),
+                               "{{".to_string(),
+                               "{{^name}}".to_string(),
+                               "".to_string(),
+                               "{{/name}}".to_string(),
+                               "}}".to_string()),
+                       Text(" after".to_string())]);
 
-        check_tokens(compile_str("before {{#name}}{{/name}}"), &[
-            Text("before ".to_string()),
-            Section(
-                vec!("name".to_string()),
-                false,
-                Vec::new(),
-                "{{".to_string(),
-                "{{#name}}".to_string(),
-                "".to_string(),
-                "{{/name}}".to_string(),
-                "}}".to_string()
-            )
-        ]);
+        check_tokens(compile_str("before {{#name}}{{/name}}"),
+                     &[Text("before ".to_string()),
+                       Section(vec!["name".to_string()],
+                               false,
+                               Vec::new(),
+                               "{{".to_string(),
+                               "{{#name}}".to_string(),
+                               "".to_string(),
+                               "{{/name}}".to_string(),
+                               "}}".to_string())]);
 
-        check_tokens(compile_str("{{#name}}{{/name}} after"), &[
-            Section(
-                vec!("name".to_string()),
-                false,
-                Vec::new(),
-                "{{".to_string(),
-                "{{#name}}".to_string(),
-                "".to_string(),
-                "{{/name}}".to_string(),
-                "}}".to_string()
-            ),
-            Text(" after".to_string())
-        ]);
+        check_tokens(compile_str("{{#name}}{{/name}} after"),
+                     &[Section(vec!["name".to_string()],
+                               false,
+                               Vec::new(),
+                               "{{".to_string(),
+                               "{{#name}}".to_string(),
+                               "".to_string(),
+                               "{{/name}}".to_string(),
+                               "}}".to_string()),
+                       Text(" after".to_string())]);
 
-        check_tokens(compile_str(
-                "before {{#a}} 1 {{^b}} 2 {{/b}} {{/a}} after"), &[
-            Text("before ".to_string()),
-            Section(
-                vec!("a".to_string()),
-                false,
-                vec!(
-                    Text(" 1 ".to_string()),
-                    Section(
-                        vec!("b".to_string()),
-                        true,
-                        vec!(Text(" 2 ".to_string())),
-                        "{{".to_string(),
-                        "{{^b}}".to_string(),
-                        " 2 ".to_string(),
-                        "{{/b}}".to_string(),
-                        "}}".to_string()
-                    ),
-                    Text(" ".to_string())
-                ),
-                "{{".to_string(),
-                "{{#a}}".to_string(),
-                " 1 {{^b}} 2 {{/b}} ".to_string(),
-                "{{/a}}".to_string(),
-                "}}".to_string()
-            ),
-            Text(" after".to_string())
-        ]);
+        check_tokens(compile_str("before {{#a}} 1 {{^b}} 2 {{/b}} {{/a}} after"),
+                     &[Text("before ".to_string()),
+                       Section(vec!["a".to_string()],
+                               false,
+                               vec![Text(" 1 ".to_string()),
+                                    Section(vec!["b".to_string()],
+                                            true,
+                                            vec![Text(" 2 ".to_string())],
+                                            "{{".to_string(),
+                                            "{{^b}}".to_string(),
+                                            " 2 ".to_string(),
+                                            "{{/b}}".to_string(),
+                                            "}}".to_string()),
+                                    Text(" ".to_string())],
+                               "{{".to_string(),
+                               "{{#a}}".to_string(),
+                               " 1 {{^b}} 2 {{/b}} ".to_string(),
+                               "{{/a}}".to_string(),
+                               "}}".to_string()),
+                       Text(" after".to_string())]);
     }
 
     #[test]
     fn test_compile_partials() {
-        check_tokens(compile_str("{{> test}}"), &[
-            Partial("test".to_string(), "".to_string(), "{{> test}}".to_string())
-        ]);
+        check_tokens(compile_str("{{> test}}"),
+                     &[Partial("test".to_string(), "".to_string(), "{{> test}}".to_string())]);
 
-        check_tokens(compile_str("before {{>test}} after"), &[
-            Text("before ".to_string()),
-            Partial("test".to_string(), "".to_string(), "{{>test}}".to_string()),
-            Text(" after".to_string())
-        ]);
+        check_tokens(compile_str("before {{>test}} after"),
+                     &[Text("before ".to_string()),
+                       Partial("test".to_string(), "".to_string(), "{{>test}}".to_string()),
+                       Text(" after".to_string())]);
 
-        check_tokens(compile_str("before {{> test}}"), &[
-            Text("before ".to_string()),
-            Partial("test".to_string(), "".to_string(), "{{> test}}".to_string())
-        ]);
+        check_tokens(compile_str("before {{> test}}"),
+                     &[Text("before ".to_string()),
+                       Partial("test".to_string(), "".to_string(), "{{> test}}".to_string())]);
 
-        check_tokens(compile_str("{{>test}} after"), &[
-            Partial("test".to_string(), "".to_string(), "{{>test}}".to_string()),
-            Text(" after".to_string())
-        ]);
+        check_tokens(compile_str("{{>test}} after"),
+                     &[Partial("test".to_string(), "".to_string(), "{{>test}}".to_string()),
+                       Text(" after".to_string())]);
     }
 
     #[test]
     fn test_compile_delimiters() {
-        check_tokens(compile_str("before {{=<% %>=}}<%name%> after"), &[
-            Text("before ".to_string()),
-            ETag(vec!("name".to_string()), "<%name%>".to_string()),
-            Text(" after".to_string())
-        ]);
+        check_tokens(compile_str("before {{=<% %>=}}<%name%> after"),
+                     &[Text("before ".to_string()),
+                       ETag(vec!["name".to_string()], "<%name%>".to_string()),
+                       Text(" after".to_string())]);
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -7,11 +7,13 @@ use std::str;
 use parser::{Parser, Token};
 use super::Context;
 
+pub type PartialsMap = HashMap<String, Vec<Token>>;
+
 /// `Compiler` is a object that compiles a string into a `Vec<Token>`.
 pub struct Compiler<T> {
     ctx: Context,
     reader: T,
-    partials: HashMap<String, Vec<Token>>,
+    partials: PartialsMap,
     otag: String,
     ctag: String,
 }
@@ -31,7 +33,7 @@ impl<T: Iterator<Item = char>> Compiler<T> {
     /// Construct a default compiler.
     pub fn new_with(ctx: Context,
                     reader: T,
-                    partials: HashMap<String, Vec<Token>>,
+                    partials: PartialsMap,
                     otag: String,
                     ctag: String)
                     -> Compiler<T> {
@@ -45,7 +47,7 @@ impl<T: Iterator<Item = char>> Compiler<T> {
     }
 
     /// Compiles a template into a series of tokens.
-    pub fn compile(mut self) -> (Vec<Token>, HashMap<String, Vec<Token>>) {
+    pub fn compile(mut self) -> (Vec<Token>, PartialsMap) {
         let (tokens, partials) = {
             let parser = Parser::new(&mut self.reader, &self.otag, &self.ctag);
             parser.parse()

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -322,12 +322,12 @@ impl rustc_serialize::Encoder for Encoder {
         };
         let mut m = match self.data.pop() {
             Some(Map(m)) => m,
-            _ => panic!("Expected a map"),
+            _ => bug!("Expected a map"),
         };
         try!(f(self));
         let popped = match self.data.pop() {
             Some(p) => p,
-            None => panic!("Error: Nothing to pop!"),
+            None => bug!("Nothing to pop!"),
         };
         m.insert(k, popped);
         self.data.push(Map(m));
@@ -341,6 +341,6 @@ pub fn encode<T: rustc_serialize::Encodable>(data: &T) -> Result<Data, Error> {
     assert_eq!(encoder.data.len(), 1);
     match encoder.data.pop() {
         Some(data) => Ok(data),
-        None => panic!("Error: Nothing to pop!"),
+        None => bug!("Nothing to pop!"),
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,14 +1,11 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::io::Error as StdIoError;
 use std::error;
 use std::iter::repeat;
 use rustc_serialize;
 
 use super::{Data, StrVal, Bool, VecVal, Map, OptVal};
 pub use self::Error::*;
-
-use parser;
 
 #[derive(Default)]
 pub struct Encoder {
@@ -25,12 +22,8 @@ impl Encoder {
 pub enum Error {
     NestedOptions,
     UnsupportedType,
-    InvalidStr,
     MissingElements,
     KeyIsNotString,
-    NoFilename,
-    IoError(StdIoError),
-    ParseError(parser::Error),
     NoDataToEncode,
     MultipleRootsFound,
 }
@@ -44,33 +37,16 @@ impl fmt::Display for Error {
 
 impl error::Error for Error {
     fn description(&self) -> &str {
-        use std::error::Error;
         match *self {
             NestedOptions => "nested Option types are not supported",
             UnsupportedType => "unsupported type",
-            InvalidStr => "invalid str",
             MissingElements => "no elements in value",
             KeyIsNotString => "key is not a string",
-            NoFilename => "a filename must be provided",
-            IoError(ref err) => err.description(),
-            ParseError(ref err) => err.description(),
             NoDataToEncode => "the encodable type created no data",
             MultipleRootsFound => {
                 "the encodable type emitted data that was not tree-like in structure"
             }
         }
-    }
-}
-
-impl From<StdIoError> for Error {
-    fn from(err: StdIoError) -> Error {
-        IoError(err)
-    }
-}
-
-impl From<parser::Error> for Error {
-    fn from(err: parser::Error) -> Error {
-        ParseError(err)
     }
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -17,6 +17,10 @@ impl Encoder {
     }
 }
 
+/// Error type to represent encoding failure.
+///
+/// This type is not intended to be matched exhaustively as new variants
+/// may be added in future without a version bump.
 #[derive(Debug)]
 pub enum Error {
     NestedOptions,
@@ -25,6 +29,9 @@ pub enum Error {
     KeyIsNotString,
     NoDataToEncode,
     MultipleRootsFound,
+
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl fmt::Display for Error {
@@ -45,6 +52,7 @@ impl error::Error for Error {
             MultipleRootsFound => {
                 "the encodable type emitted data that was not tree-like in structure"
             }
+            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -63,125 +63,170 @@ pub type EncoderResult = Result<(), Error>;
 impl rustc_serialize::Encoder for Encoder {
     type Error = Error;
 
-    fn emit_nil(&mut self) -> EncoderResult { Err(UnsupportedType) }
+    fn emit_nil(&mut self) -> EncoderResult {
+        Err(UnsupportedType)
+    }
 
-    fn emit_isize(&mut self, v: isize) -> EncoderResult { self.data.push(StrVal(v.to_string())); Ok(()) }
-    fn emit_usize(&mut self, v: usize) -> EncoderResult { self.data.push(StrVal(v.to_string())); Ok(()) }
-    fn emit_u64(&mut self, v: u64) -> EncoderResult   { self.data.push(StrVal(v.to_string())); Ok(()) }
-    fn emit_u32(&mut self, v: u32) -> EncoderResult   { self.data.push(StrVal(v.to_string())); Ok(()) }
-    fn emit_u16(&mut self, v: u16) -> EncoderResult   { self.data.push(StrVal(v.to_string())); Ok(()) }
-    fn emit_u8(&mut self, v: u8) -> EncoderResult     { self.data.push(StrVal(v.to_string())); Ok(()) }
+    fn emit_isize(&mut self, v: isize) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
+    fn emit_usize(&mut self, v: usize) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
+    fn emit_u64(&mut self, v: u64) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
+    fn emit_u32(&mut self, v: u32) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
+    fn emit_u16(&mut self, v: u16) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
+    fn emit_u8(&mut self, v: u8) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
 
-    fn emit_i64(&mut self, v: i64) -> EncoderResult { self.data.push(StrVal(v.to_string())); Ok(()) }
-    fn emit_i32(&mut self, v: i32) -> EncoderResult { self.data.push(StrVal(v.to_string())); Ok(()) }
-    fn emit_i16(&mut self, v: i16) -> EncoderResult { self.data.push(StrVal(v.to_string())); Ok(()) }
-    fn emit_i8(&mut self, v: i8) -> EncoderResult   { self.data.push(StrVal(v.to_string())); Ok(()) }
+    fn emit_i64(&mut self, v: i64) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
+    fn emit_i32(&mut self, v: i32) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
+    fn emit_i16(&mut self, v: i16) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
+    fn emit_i8(&mut self, v: i8) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
 
-    fn emit_bool(&mut self, v: bool) -> EncoderResult { self.data.push(Bool(v)); Ok(()) }
+    fn emit_bool(&mut self, v: bool) -> EncoderResult {
+        self.data.push(Bool(v));
+        Ok(())
+    }
 
-    fn emit_f64(&mut self, v: f64) -> EncoderResult { self.data.push(StrVal(v.to_string())); Ok(()) }
-    fn emit_f32(&mut self, v: f32) -> EncoderResult { self.data.push(StrVal(v.to_string())); Ok(()) }
+    fn emit_f64(&mut self, v: f64) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
+    fn emit_f32(&mut self, v: f32) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
 
     fn emit_char(&mut self, v: char) -> EncoderResult {
         self.data.push(StrVal(repeat(v).take(1).collect::<String>()));
         Ok(())
     }
-    fn emit_str(&mut self, v: &str) -> EncoderResult { self.data.push(StrVal(v.to_string())); Ok(()) }
+    fn emit_str(&mut self, v: &str) -> EncoderResult {
+        self.data.push(StrVal(v.to_string()));
+        Ok(())
+    }
 
-    fn emit_enum< F >(&mut self, _name: &str, _f: F ) -> EncoderResult
-    where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_enum<F>(&mut self, _name: &str, _f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         Err(UnsupportedType)
     }
 
-    fn emit_enum_variant< F >(&mut self,
-                         _name: &str,
-                         _id: usize,
-                         _len: usize,
-                         _f: F) -> EncoderResult
-                         where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_enum_variant<F>(&mut self, _name: &str, _id: usize, _len: usize, _f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         Err(UnsupportedType)
     }
 
-    fn emit_enum_variant_arg< F >(&mut self,
-                             _a_idx: usize,
-                             _f: F) -> EncoderResult
-                             where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_enum_variant_arg<F>(&mut self, _a_idx: usize, _f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         Err(UnsupportedType)
     }
 
-    fn emit_enum_struct_variant< F >(&mut self,
-                                _v_name: &str,
-                                _v_id: usize,
-                                _len: usize,
-                                _f: F) -> EncoderResult
-                                where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_enum_struct_variant<F>(&mut self,
+                                   _v_name: &str,
+                                   _v_id: usize,
+                                   _len: usize,
+                                   _f: F)
+                                   -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         Err(UnsupportedType)
     }
 
-    fn emit_enum_struct_variant_field< F >(&mut self,
-                                      _f_name: &str,
-                                      _f_idx: usize,
-                                      _f: F) -> EncoderResult
-                                      where F : FnOnce(&mut Encoder) -> EncoderResult  {
+    fn emit_enum_struct_variant_field<F>(&mut self,
+                                         _f_name: &str,
+                                         _f_idx: usize,
+                                         _f: F)
+                                         -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         Err(UnsupportedType)
     }
 
-    fn emit_struct< F >(&mut self,
-                   _name: &str,
-                   _len: usize,
-                   f: F) -> EncoderResult
-                   where F : FnOnce(&mut Encoder) -> EncoderResult  {
+    fn emit_struct<F>(&mut self, _name: &str, _len: usize, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         self.data.push(Map(HashMap::new()));
         f(self)
     }
 
-    fn emit_struct_field< F >(&mut self,
-                         name: &str,
-                         _idx: usize,
-                         f: F) -> EncoderResult
-                         where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_struct_field<F>(&mut self, name: &str, _idx: usize, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         let mut m = match self.data.pop() {
             Some(Map(m)) => m,
-            _ => { return Err(UnsupportedType); }
+            _ => {
+                return Err(UnsupportedType);
+            }
         };
         try!(f(self));
         let data = match self.data.pop() {
             Some(d) => d,
-            _ => { return Err(UnsupportedType); }
+            _ => {
+                return Err(UnsupportedType);
+            }
         };
         m.insert(name.to_string(), data);
         self.data.push(Map(m));
         Ok(())
     }
 
-    fn emit_tuple< F >(&mut self,
-                  len: usize,
-                  f: F) -> EncoderResult
-                  where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_tuple<F>(&mut self, len: usize, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         self.emit_seq(len, f)
     }
 
-    fn emit_tuple_arg< F >(&mut self, idx: usize, f: F) -> EncoderResult
-    where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_tuple_arg<F>(&mut self, idx: usize, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         self.emit_seq_elt(idx, f)
     }
 
-    fn emit_tuple_struct< F >(&mut self,
-                         _name: &str,
-                         len: usize,
-                         f: F) -> EncoderResult
-                         where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_tuple_struct<F>(&mut self, _name: &str, len: usize, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         self.emit_seq(len, f)
     }
 
-    fn emit_tuple_struct_arg< F >(&mut self, idx: usize, f: F) -> EncoderResult
-    where F : FnOnce(&mut Encoder) -> EncoderResult  {
+    fn emit_tuple_struct_arg<F>(&mut self, idx: usize, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         self.emit_seq_elt(idx, f)
     }
 
     // Specialized types:
-    fn emit_option< F >(&mut self, f: F) -> EncoderResult
-    where F : FnOnce(&mut Encoder) -> EncoderResult  {
+    fn emit_option<F>(&mut self, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         f(self)
     }
 
@@ -190,52 +235,65 @@ impl rustc_serialize::Encoder for Encoder {
         Ok(())
     }
 
-    fn emit_option_some< F >(&mut self, f: F) -> EncoderResult
-  where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_option_some<F>(&mut self, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         try!(f(self));
         let val = match self.data.pop() {
-            Some(OptVal(_)) => { return Err(NestedOptions) },
+            Some(OptVal(_)) => return Err(NestedOptions),
             Some(d) => d,
-            _ => { return Err(UnsupportedType); }
+            _ => {
+                return Err(UnsupportedType);
+            }
         };
         self.data.push(OptVal(Some(Box::new(val))));
         Ok(())
     }
 
-    fn emit_seq< F >(&mut self, _len: usize, f: F) -> EncoderResult
-  where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_seq<F>(&mut self, _len: usize, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         self.data.push(VecVal(Vec::new()));
         f(self)
     }
 
-    fn emit_seq_elt< F >(&mut self, _idx: usize, f: F) -> EncoderResult
-  where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_seq_elt<F>(&mut self, _idx: usize, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         let mut v = match self.data.pop() {
             Some(VecVal(v)) => v,
-            _ => { return Err(UnsupportedType); }
+            _ => {
+                return Err(UnsupportedType);
+            }
         };
         try!(f(self));
         let data = match self.data.pop() {
             Some(d) => d,
-            _ => { return Err(UnsupportedType); }
+            _ => {
+                return Err(UnsupportedType);
+            }
         };
         v.push(data);
         self.data.push(VecVal(v));
         Ok(())
     }
 
-    fn emit_map< F >(&mut self, _len: usize, f: F) -> EncoderResult
-  where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_map<F>(&mut self, _len: usize, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         self.data.push(Map(HashMap::new()));
         f(self)
     }
 
-    fn emit_map_elt_key< F >(&mut self, _idx: usize, f: F) -> EncoderResult
-  where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_map_elt_key<F>(&mut self, _idx: usize, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         try!(f(self));
         let last = match self.data.last() {
             Some(d) => d,
-            None => { return Err(MissingElements); }
+            None => {
+                return Err(MissingElements);
+            }
         };
         match *last {
             StrVal(_) => Ok(()),
@@ -243,11 +301,14 @@ impl rustc_serialize::Encoder for Encoder {
         }
     }
 
-    fn emit_map_elt_val< F >(&mut self, _idx: usize, f: F) -> EncoderResult
-  where F : FnOnce(&mut Encoder) -> EncoderResult {
+    fn emit_map_elt_val<F>(&mut self, _idx: usize, f: F) -> EncoderResult
+    where F: FnOnce(&mut Encoder) -> EncoderResult
+    {
         let k = match self.data.pop() {
             Some(StrVal(s)) => s,
-            _ => { return Err(KeyIsNotString); }
+            _ => {
+                return Err(KeyIsNotString);
+            }
         };
         let mut m = match self.data.pop() {
             Some(Map(m)) => m,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -8,12 +8,16 @@ use self::Error::*;
 
 #[derive(Default)]
 pub struct Encoder {
-    pub data: Vec<Data>,
+     data: Vec<Data>,
 }
 
 impl Encoder {
     pub fn new() -> Encoder {
         Encoder::default()
+    }
+
+    pub fn stack(&self) -> &[Data] {
+        &self.data
     }
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -8,6 +8,8 @@ use rustc_serialize;
 use super::{Data, StrVal, Bool, VecVal, Map, OptVal};
 pub use self::Error::*;
 
+use parser;
+
 #[derive(Default)]
 pub struct Encoder {
     pub data: Vec<Data>,
@@ -28,6 +30,7 @@ pub enum Error {
     KeyIsNotString,
     NoFilename,
     IoError(StdIoError),
+    ParseError(parser::Error),
 }
 
 impl fmt::Display for Error {
@@ -48,6 +51,7 @@ impl error::Error for Error {
             KeyIsNotString => "key is not a string",
             NoFilename => "a filename must be provided",
             IoError(ref err) => err.description(),
+            ParseError(ref err) => err.description(),
         }
     }
 }
@@ -55,6 +59,12 @@ impl error::Error for Error {
 impl From<StdIoError> for Error {
     fn from(err: StdIoError) -> Error {
         IoError(err)
+    }
+}
+
+impl From<parser::Error> for Error {
+    fn from(err: parser::Error) -> Error {
+        ParseError(err)
     }
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -4,7 +4,7 @@ use std::error;
 use rustc_serialize;
 
 use super::{Data, StrVal, Bool, VecVal, Map, OptVal};
-pub use self::Error::*;
+use self::Error::*;
 
 #[derive(Default)]
 pub struct Encoder {

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,11 @@ use std::fmt;
 use parser;
 use encoder;
 
+
+/// Error type for any error within this library.
+///
+/// This type is not intended to be matched exhaustively as new variants
+/// may be added in future without a version bump.
 #[derive(Debug)]
 pub enum Error {
     InvalidStr,
@@ -12,6 +17,9 @@ pub enum Error {
     Io(StdIoError),
     Parser(parser::Error),
     Encoder(encoder::Error),
+
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl fmt::Display for Error {
@@ -28,6 +36,7 @@ impl StdError for Error {
             Error::Io(ref err) => err.description(),
             Error::Parser(ref err) => err.description(),
             Error::Encoder(ref err) => err.description(),
+            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,6 @@ use std::fmt;
 use parser;
 use encoder;
 
-
 /// Error type for any error within this library.
 ///
 /// This type is not intended to be matched exhaustively as new variants

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,51 @@
+use std::error::Error as StdError;
+use std::io::Error as StdIoError;
+use std::fmt;
+
+use parser;
+use encoder;
+
+#[derive(Debug)]
+pub enum Error {
+    InvalidStr,
+    NoFilename,
+    Io(StdIoError),
+    Parser(parser::Error),
+    Encoder(encoder::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.description().fmt(f)
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::InvalidStr => "invalid str",
+            Error::NoFilename => "a filename must be provided",
+            Error::Io(ref err) => err.description(),
+            Error::Parser(ref err) => err.description(),
+            Error::Encoder(ref err) => err.description(),
+        }
+    }
+}
+
+impl From<StdIoError> for Error {
+    fn from(err: StdIoError) -> Error {
+        Error::Io(err)
+    }
+}
+
+impl From<parser::Error> for Error {
+    fn from(err: parser::Error) -> Error {
+        Error::Parser(err)
+    }
+}
+
+impl From<encoder::Error> for Error {
+    fn from(err: encoder::Error) -> Error {
+        Error::Encoder(err)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,9 @@ use std::result::Result as StdResult;
 
 pub use self::Data::*;
 pub use builder::{MapBuilder, VecBuilder};
-pub use encoder::{Error, IoError, InvalidStr, Encoder, EncoderResult};
+pub use encoder::{Encoder, EncoderResult};
 pub use template::Template;
+pub use error::Error;
 
 #[macro_use]
 mod macros;
@@ -33,6 +34,7 @@ pub mod encoder;
 mod compiler;
 mod parser;
 mod template;
+mod error;
 
 pub enum Data {
     OptVal(Option<Box<Data>>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@
 
 extern crate rustc_serialize;
 extern crate log;
-#[cfg(test)]extern crate tempdir;
+#[cfg(test)]
+extern crate tempdir;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -77,7 +78,8 @@ pub struct Context {
 
 impl fmt::Debug for Context {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Context {{ template_path: {:?}, template_extension: {} }}",
+        write!(f,
+               "Context {{ template_path: {:?}, template_extension: {} }}",
                &*self.template_path,
                self.template_extension)
     }
@@ -93,7 +95,7 @@ impl Context {
     }
 
     /// Compiles a template from a string
-    pub fn compile<IT: Iterator<Item=char>>(&self, reader: IT) -> Template {
+    pub fn compile<IT: Iterator<Item = char>>(&self, reader: IT) -> Template {
         let compiler = compiler::Compiler::new(self.clone(), reader);
         let (tokens, partials) = compiler.compile();
 
@@ -113,7 +115,9 @@ impl Context {
         // TODO: maybe allow UTF-16 as well?
         let template = match str::from_utf8(&*s) {
             Ok(string) => string,
-            _ => { return Result::Err(Error::InvalidStr); }
+            _ => {
+                return Result::Err(Error::InvalidStr);
+            }
         };
 
         Ok(self.compile(template.chars()))
@@ -121,7 +125,7 @@ impl Context {
 }
 
 /// Compiles a template from an `Iterator<char>`.
-pub fn compile_iter<T: Iterator<Item=char>>(iter: T) -> Template {
+pub fn compile_iter<T: Iterator<Item = char>>(iter: T) -> Template {
     Context::new(PathBuf::from(".")).compile(iter)
 }
 
@@ -135,17 +139,15 @@ pub fn compile_path<U: AsRef<Path>>(path: U) -> Result<Template, Error> {
             let template_dir = path.parent().unwrap_or(Path::new("."));
             // FIXME: Should work with OsStrings, this will not use provided extension if
             // the extension is not utf8 :(
-            let extension = path.extension()
-                                .and_then(|ext| ext.to_str())
-                                .unwrap_or("mustache");
+            let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or("mustache");
 
             let context = Context {
                 template_path: template_dir.to_path_buf(),
-                template_extension: extension.to_string()
+                template_extension: extension.to_string(),
             };
             context.compile_path(filename)
         }
-        None => Result::Err(Error::NoFilename)
+        None => Result::Err(Error::NoFilename),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub enum Data {
 
 pub type Result<T = ()> = StdResult<T, Error>;
 
-impl<'a> PartialEq for Data {
+impl PartialEq for Data {
     #[inline]
     fn eq(&self, other: &Data) -> bool {
         match (self, other) {
@@ -60,7 +60,7 @@ impl<'a> PartialEq for Data {
     }
 }
 
-impl<'a> fmt::Debug for Data {
+impl fmt::Debug for Data {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             OptVal(ref v) => write!(f, "OptVal({:?})", v),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ pub use builder::{MapBuilder, VecBuilder};
 pub use encoder::{Error, IoError, InvalidStr, Encoder, EncoderResult};
 pub use template::Template;
 
+#[macro_use]
+mod macros;
+
 pub mod builder;
 pub mod encoder;
 
@@ -51,7 +54,7 @@ impl<'a> PartialEq for Data {
             (&Bool(ref v0), &Bool(ref v1)) => v0 == v1,
             (&VecVal(ref v0), &VecVal(ref v1)) => v0 == v1,
             (&Map(ref v0), &Map(ref v1)) => v0 == v1,
-            (&Fun(_), &Fun(_)) => panic!("cannot compare closures"),
+            (&Fun(_), &Fun(_)) => bug!("Cannot compare closures"),
             (_, _) => false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 
-#![allow(unused_attributes)]
-
 extern crate rustc_serialize;
 extern crate log;
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,17 @@ mod macros;
 pub mod builder;
 pub mod encoder;
 
+
+// FIXME: When pub(crate) lands then this can be made a lot less awkward.
+// Alternatively, decide on a decent part of the parser api to consider stable.
+pub mod parser {
+    pub use parser_internals::Error;
+}
+
+#[path = "parser.rs"]
+mod parser_internals;
+
 mod compiler;
-mod parser;
 mod template;
 mod error;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,16 @@
+/// This should be the only place to panic inside non-test code.
+// TODO: ensure no panics elsewhere via clippy
+macro_rules! bug {
+    ($msg:expr) => ({
+        bug!("{}", $msg)
+    });
+    ($fmt:expr, $($arg:tt)+) => ({
+        panic!(
+            concat!("bug: ",
+                    $fmt,
+                    ". Please report this issue on GitHub if you find \
+                    an input that triggers this case."),
+            $($arg)*
+        )
+    });
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,3 +14,16 @@ macro_rules! bug {
         )
     });
 }
+
+#[cfg(test)]
+macro_rules! assert_let {
+    (@as_block $block:block) => { $block };
+    ($pattern:pat = $thing:expr => $($block:tt)*) => {
+        match $thing {
+            $pattern => assert_let!(@as_block { $($block)* }),
+            ref failure => {
+                panic!("assertion failed: expected `{:?}`, found `{:?}`", stringify!($pattern), failure)
+            }
+        }
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,6 +18,9 @@ macro_rules! bug {
 #[cfg(test)]
 macro_rules! assert_let {
     (@as_block $block:block) => { $block };
+    ($pattern:pat = $thing:expr) => {
+        assert_let!($pattern = $thing => {});
+    };
     ($pattern:pat = $thing:expr => $($block:tt)*) => {
         match $thing {
             $pattern => assert_let!(@as_block { $($block)* }),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,8 +10,8 @@ use self::TokenClass::*;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token {
     Text(String),
-    ETag(Vec<String>, String),
-    UTag(Vec<String>, String),
+    EscapedTag(Vec<String>, String),
+    UnescapedTag(Vec<String>, String),
     Section(Vec<String>, bool, Vec<Token>, String, String, String, String, String),
     IncompleteSection(Vec<String>, bool, String, bool),
     Partial(String, String, String),
@@ -372,14 +372,14 @@ impl<'a, T: Iterator<Item = char>> Parser<'a, T> {
                 let name = &content[1..len];
                 let name = try!(deny_blank(name));
                 let name = name.split_terminator('.').map(|x| x.to_string()).collect();
-                self.tokens.push(UTag(name, tag));
+                self.tokens.push(UnescapedTag(name, tag));
             }
             '{' => {
                 if content.ends_with('}') {
                     let name = &content[1..len - 1];
                     let name = try!(deny_blank(name));
                     let name = name.split_terminator('.').map(|x| x.to_string()).collect();
-                    self.tokens.push(UTag(name, tag));
+                    self.tokens.push(UnescapedTag(name, tag));
                 } else {
                     return Err(Error::UnbalancedUnescapeTag)
                 }
@@ -421,8 +421,8 @@ impl<'a, T: Iterator<Item = char>> Parser<'a, T> {
                             for child in children.iter() {
                                 match *child {
                                     Text(ref s) |
-                                    ETag(_, ref s) |
-                                    UTag(_, ref s) |
+                                    EscapedTag(_, ref s) |
+                                    UnescapedTag(_, ref s) |
                                     Partial(_, _, ref s) => srcs.push(s.clone()),
                                     Section(_, _, _, _, ref osection, ref src, ref csection, _) => {
                                         srcs.push(osection.clone());
@@ -504,7 +504,7 @@ impl<'a, T: Iterator<Item = char>> Parser<'a, T> {
                     name.split_terminator('.').map(|x| x.to_string()).collect()
                 };
 
-                self.tokens.push(ETag(name, tag));
+                self.tokens.push(EscapedTag(name, tag));
             }
         };
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -429,9 +429,7 @@ impl<'a, T: Iterator<Item = char>> Parser<'a, T> {
                                         srcs.push(src.clone());
                                         srcs.push(csection.clone());
                                     }
-                                    _ => unreachable!("bug: Incomplete sections should not be nested \
-                                                       Please report this issue on GitHub if you find \
-                                                       an input that triggers this case."),
+                                    _ => bug!("Incomplete sections should not be nested"),
                                 }
                             }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,7 @@ use self::TokenClass::*;
 use self::ParserState::*;
 
 /// `Token` is a section of a compiled mustache string.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Token {
     Text(String),
     ETag(Vec<String>, String),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -254,7 +254,7 @@ impl<'a, T: Iterator<Item = char>> Parser<'a, T> {
         }
 
         // Check that we don't have any incomplete sections.
-        for token in self.tokens.iter() {
+        for token in self.tokens.iter().rev() {
             if let IncompleteSection(ref path, _, _, _) = *token {
                 return Err(Error::UnclosedSection(path.join(".")))
             }
@@ -644,7 +644,6 @@ mod tests {
         }
 
         #[test]
-        #[ignore(reason = "currently wrong behaviour")]
         fn unclosed_nested() {
             assert_eq!(
                 parse("{{#universe}} {{#world}}"),
@@ -694,7 +693,6 @@ mod tests {
         }
 
         #[test]
-        #[ignore(reason = "currently wrong behaviour")]
         fn unclosed_nested() {
             assert_eq!(
                 parse("{{#universe}} {{^world}}"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -17,6 +17,10 @@ pub enum Token {
     Partial(String, String, String),
 }
 
+/// Error type to represent parsing failure.
+///
+/// This type is not intended to be matched exhaustively as new variants
+/// may be added in future without a version bump.
 #[derive(Debug, PartialEq)]
 pub enum Error {
     BadClosingTag(char, char),
@@ -27,6 +31,9 @@ pub enum Error {
     EarlySectionClose(String),
     MissingSetDelimeterClosingTag,
     InvalidSetDelimeterSyntax,
+
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl StdError for Error {
@@ -40,6 +47,7 @@ impl StdError for Error {
             Error::EarlySectionClose(..) => "found a closing tag for an unopened section",
             Error::MissingSetDelimeterClosingTag => "missing the new closing tag in set delimeter tag",
             Error::InvalidSetDelimeterSyntax => "invalid set delimeter tag syntax",
+            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -154,9 +154,7 @@ impl<'a> RenderContext<'a> {
 
         try!(self.render_utag(&mut bytes, stack, path));
 
-        let s = str::from_utf8(&bytes).unwrap();
-
-        for b in s.bytes() {
+        for b in bytes {
             match b {
                 b'<' => {
                     try!(wr.write_all(b"&lt;"));

--- a/src/template.rs
+++ b/src/template.rs
@@ -6,8 +6,8 @@ use rustc_serialize::Encodable;
 
 use encoder;
 use compiler::Compiler;
-use parser::Token;
-use parser::Token::*;
+use parser_internals::Token;
+use parser_internals::Token::*;
 
 use super::{Context, Data, Bool, StrVal, VecVal, Map, Fun, OptVal, Result};
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -419,13 +419,13 @@ mod tests {
         ::compile_str(s).expect(&format!("Failed to compile: {}", s))
     }
 
-    fn assert_render<'a, 'b, T: Encodable + Debug>(template: &str, data: &T) -> String {
+    fn assert_render<T: Encodable + Debug>(template: &str, data: &T) -> String {
         render(template, data).expect(&format!("Failed to render: template: {:?}\ndata: {:?}",
                                                 template,
                                                 data))
     }
 
-    fn render<'a, 'b, T: Encodable>(template: &str, data: &T) -> Result<String, Error> {
+    fn render<T: Encodable>(template: &str, data: &T) -> Result<String, Error> {
         let template = compile_str(template);
 
         let mut bytes = vec![];

--- a/src/template.rs
+++ b/src/template.rs
@@ -17,13 +17,12 @@ use super::{Context, Data, Bool, StrVal, VecVal, Map, Fun, OptVal};
 pub struct Template {
     ctx: Context,
     tokens: Vec<Token>,
-    partials: HashMap<String, Vec<Token>>
+    partials: HashMap<String, Vec<Token>>,
 }
 
 /// Construct a `Template`. This is not part of the impl of Template so it is
 /// not exported outside of mustache.
-pub fn new(ctx: Context, tokens: Vec<Token>, partials: HashMap<String,
-Vec<Token>>) -> Template {
+pub fn new(ctx: Context, tokens: Vec<Token>, partials: HashMap<String, Vec<Token>>) -> Template {
     Template {
         ctx: ctx,
         tokens: tokens,
@@ -33,11 +32,7 @@ Vec<Token>>) -> Template {
 
 impl Template {
     /// Renders the template with the `Encodable` data.
-    pub fn render<W: Write, T: Encodable>(
-        &self,
-        wr: &mut W,
-        data: &T
-    ) -> Result<(), Error> {
+    pub fn render<W: Write, T: Encodable>(&self, wr: &mut W, data: &T) -> Result<(), Error> {
         let data = try!(encoder::encode(data));
         Ok(self.render_data(wr, &data))
     }
@@ -45,12 +40,9 @@ impl Template {
     /// Renders the template with the `Data`.
     pub fn render_data<W: Write>(&self, wr: &mut W, data: &Data) {
         let mut render_ctx = RenderContext::new(self);
-        let mut stack = vec!(data);
+        let mut stack = vec![data];
 
-        render_ctx.render(
-            wr,
-            &mut stack,
-            &self.tokens);
+        render_ctx.render(wr, &mut stack, &self.tokens);
     }
 }
 
@@ -69,27 +61,17 @@ impl<'a> RenderContext<'a> {
         }
     }
 
-    fn render<W: Write>(
-        &mut self,
-        wr: &mut W,
-        stack: &mut Vec<&Data>,
-        tokens: &[Token]
-    ) {
+    fn render<W: Write>(&mut self, wr: &mut W, stack: &mut Vec<&Data>, tokens: &[Token]) {
         for token in tokens.iter() {
             self.render_token(wr, stack, token);
         }
     }
 
-    fn render_token<W: Write>(
-        &mut self,
-        wr: &mut W,
-        stack: &mut Vec<&Data>,
-        token: &Token
-    ) {
+    fn render_token<W: Write>(&mut self, wr: &mut W, stack: &mut Vec<&Data>, token: &Token) {
         match *token {
             Text(ref value) => {
                 self.render_text(wr, value);
-            },
+            }
             ETag(ref path, _) => {
                 self.render_etag(wr, stack, path);
             }
@@ -100,19 +82,12 @@ impl<'a> RenderContext<'a> {
                 self.render_inverted_section(wr, stack, path, children);
             }
             Section(ref path, false, ref children, ref otag, _, ref src, _, ref ctag) => {
-                self.render_section(
-                    wr,
-                    stack,
-                    path,
-                    children,
-                    src,
-                    otag,
-                    ctag)
+                self.render_section(wr, stack, path, children, src, otag, ctag)
             }
             Partial(ref name, ref indent, _) => {
                 self.render_partial(wr, stack, name, indent);
             }
-            _ => { panic!() }
+            _ => panic!(),
         }
     }
 
@@ -121,7 +96,7 @@ impl<'a> RenderContext<'a> {
         self.line_start = match value.chars().last() {
             None => self.line_start, // None == ""
             Some('\n') => true,
-            _ => false
+            _ => false,
         };
     }
 
@@ -131,11 +106,7 @@ impl<'a> RenderContext<'a> {
         }
     }
 
-    fn render_text<W: Write>(
-        &mut self,
-        wr: &mut W,
-        value: &str
-    ) {
+    fn render_text<W: Write>(&mut self, wr: &mut W, value: &str) {
         // Indent the lines.
         if self.indent.is_empty() {
             self.write_tracking_newlines(wr, value);
@@ -167,12 +138,7 @@ impl<'a> RenderContext<'a> {
         }
     }
 
-    fn render_etag<W: Write>(
-        &mut self,
-        wr: &mut W,
-        stack: &mut Vec<&Data>,
-        path: &[String]
-    ) {
+    fn render_etag<W: Write>(&mut self, wr: &mut W, stack: &mut Vec<&Data>, path: &[String]) {
         let mut bytes = vec![];
 
         self.render_utag(&mut bytes, stack, path);
@@ -181,24 +147,31 @@ impl<'a> RenderContext<'a> {
 
         for b in s.bytes() {
             match b {
-                b'<'  => { wr.write_all(b"&lt;").unwrap(); }
-                b'>'  => { wr.write_all(b"&gt;").unwrap(); }
-                b'&'  => { wr.write_all(b"&amp;").unwrap(); }
-                b'"'  => { wr.write_all(b"&quot;").unwrap(); }
-                b'\'' => { wr.write_all(b"&#39;").unwrap(); }
-                _    => { wr.write_all(&[b]).unwrap(); }
+                b'<' => {
+                    wr.write_all(b"&lt;").unwrap();
+                }
+                b'>' => {
+                    wr.write_all(b"&gt;").unwrap();
+                }
+                b'&' => {
+                    wr.write_all(b"&amp;").unwrap();
+                }
+                b'"' => {
+                    wr.write_all(b"&quot;").unwrap();
+                }
+                b'\'' => {
+                    wr.write_all(b"&#39;").unwrap();
+                }
+                _ => {
+                    wr.write_all(&[b]).unwrap();
+                }
             }
         }
     }
 
-    fn render_utag<W: Write>(
-        &mut self,
-        wr: &mut W,
-        stack: &mut Vec<&Data>,
-        path: &[String]
-    ) {
+    fn render_utag<W: Write>(&mut self, wr: &mut W, stack: &mut Vec<&Data>, path: &[String]) {
         match self.find(path, stack) {
-            None => { }
+            None => {}
             Some(mut value) => {
                 self.write_indent(wr);
 
@@ -209,7 +182,7 @@ impl<'a> RenderContext<'a> {
                 if let OptVal(ref inner) = *value {
                     match *inner {
                         Some(ref inner) => value = inner,
-                        None => return
+                        None => return,
                     }
                 }
 
@@ -225,48 +198,48 @@ impl<'a> RenderContext<'a> {
                         self.render(wr, stack, &tokens);
                     }
 
-                    ref value => { panic!("unexpected value {:?}", value); }
+                    ref value => {
+                        panic!("unexpected value {:?}", value);
+                    }
                 }
             }
         };
     }
 
-    fn render_inverted_section<W: Write>(
-        &mut self,
-        wr: &mut W,
-        stack: &mut Vec<&Data>,
-        path: &[String],
-        children: &[Token]
-    ) {
+    fn render_inverted_section<W: Write>(&mut self,
+                                         wr: &mut W,
+                                         stack: &mut Vec<&Data>,
+                                         path: &[String],
+                                         children: &[Token]) {
         match self.find(path, stack) {
-            None => { }
-            Some(&Bool(false)) => { }
-            Some(&VecVal(ref xs)) if xs.is_empty() => { }
-            Some(&OptVal(ref val)) if val.is_none() => { }
-            Some(_) => { return; }
+            None => {}
+            Some(&Bool(false)) => {}
+            Some(&VecVal(ref xs)) if xs.is_empty() => {}
+            Some(&OptVal(ref val)) if val.is_none() => {}
+            Some(_) => {
+                return;
+            }
         }
 
         self.render(wr, stack, children);
     }
 
-    fn render_section<W: Write>(
-        &mut self,
-        wr: &mut W,
-        stack: &mut Vec<&Data>,
-        path: &[String],
-        children: &[Token],
-        src: &str,
-        otag: &str,
-        ctag: &str
-    ) {
+    fn render_section<W: Write>(&mut self,
+                                wr: &mut W,
+                                stack: &mut Vec<&Data>,
+                                path: &[String],
+                                children: &[Token],
+                                src: &str,
+                                otag: &str,
+                                ctag: &str) {
         match self.find(path, stack) {
-            None => { }
+            None => {}
             Some(value) => {
                 match *value {
                     Bool(true) => {
                         self.render(wr, stack, children);
                     }
-                    Bool(false) => { }
+                    Bool(false) => {}
                     VecVal(ref vs) => {
                         for v in vs.iter() {
                             stack.push(v);
@@ -283,7 +256,7 @@ impl<'a> RenderContext<'a> {
                         let f = &mut *fcell.borrow_mut();
                         let tokens = self.render_fun(src, otag, ctag, f);
                         self.render(wr, stack, &tokens)
-                    },
+                    }
                     OptVal(ref val) => {
                         if let Some(ref val) = *val {
                             stack.push(val);
@@ -291,21 +264,19 @@ impl<'a> RenderContext<'a> {
                             stack.pop();
                         }
                     }
-                    _ => { panic!("unexpected value {:?}", value) }
+                    _ => panic!("unexpected value {:?}", value),
                 }
             }
         }
     }
 
-    fn render_partial<W: Write>(
-        &mut self,
-        wr: &mut W,
-        stack: &mut Vec<&Data>,
-        name: &str,
-        indent: &str
-    ) {
+    fn render_partial<W: Write>(&mut self,
+                                wr: &mut W,
+                                stack: &mut Vec<&Data>,
+                                name: &str,
+                                indent: &str) {
         match self.template.partials.get(name) {
-            None => { }
+            None => {}
             Some(ref tokens) => {
                 let mut indent = self.indent.clone() + indent;
 
@@ -316,15 +287,19 @@ impl<'a> RenderContext<'a> {
         }
     }
 
-    fn render_fun(&self, src: &str, otag: &str, ctag: &str, f: &mut Box<FnMut(String) -> String + Send + 'static>) -> Vec<Token> {
+    fn render_fun(&self,
+                  src: &str,
+                  otag: &str,
+                  ctag: &str,
+                  f: &mut Box<FnMut(String) -> String + Send + 'static>)
+                  -> Vec<Token> {
         let src = f(src.to_string());
 
-        let compiler = Compiler::new_with(
-            self.template.ctx.clone(),
-            src.chars(),
-            self.template.partials.clone(),
-            otag.to_string(),
-            ctag.to_string());
+        let compiler = Compiler::new_with(self.template.ctx.clone(),
+                                          src.chars(),
+                                          self.template.partials.clone(),
+                                          otag.to_string(),
+                                          ctag.to_string());
 
         let (tokens, _) = compiler.compile();
         tokens
@@ -334,8 +309,12 @@ impl<'a> RenderContext<'a> {
         // If we have an empty path, we just want the top value in our stack.
         if path.is_empty() {
             match stack.last() {
-                None => { return None; }
-                Some(data) => { return Some(*data); }
+                None => {
+                    return None;
+                }
+                Some(data) => {
+                    return Some(*data);
+                }
             }
         }
 
@@ -350,25 +329,33 @@ impl<'a> RenderContext<'a> {
                         break;
                     }
                 }
-                _ => { panic!("expect map: {:?}", path) }
+                _ => panic!("expect map: {:?}", path),
             }
         }
 
         // Walk the rest of the path to find our final value.
         let mut value = match value {
             Some(value) => value,
-            None => { return None; }
+            None => {
+                return None;
+            }
         };
 
         for part in path[1..].iter() {
             match *value {
                 Map(ref m) => {
                     match m.get(part) {
-                        Some(v) => { value = v; }
-                        None => { return None; }
+                        Some(v) => {
+                            value = v;
+                        }
+                        None => {
+                            return None;
+                        }
                     }
                 }
-                _ => { return None; }
+                _ => {
+                    return None;
+                }
             }
         }
 
@@ -394,22 +381,25 @@ mod tests {
     use super::super::{Context, Template};
 
     #[derive(RustcEncodable)]
-    struct Planet { name: String, info: Option<PlanetInfo> }
+    struct Planet {
+        name: String,
+        info: Option<PlanetInfo>,
+    }
 
     #[derive(RustcEncodable)]
     struct PlanetInfo {
         moons: Vec<String>,
         population: u64,
-        description: String
+        description: String,
     }
 
     #[derive(RustcEncodable)]
-    struct Person { name: String, age: Option<u32> }
+    struct Person {
+        name: String,
+        age: Option<u32>,
+    }
 
-    fn render<'a, 'b, T: Encodable>(
-        template: &str,
-        data: &T,
-    ) -> Result<String, Error> {
+    fn render<'a, 'b, T: Encodable>(template: &str, data: &T) -> Result<String, Error> {
         let template = compile_str(template);
 
         let mut bytes = vec![];
@@ -420,7 +410,10 @@ mod tests {
 
     #[test]
     fn test_render_texts() {
-        let ctx = Planet { name: "world".to_string(), info: None };
+        let ctx = Planet {
+            name: "world".to_string(),
+            info: None,
+        };
 
         assert_eq!(&*render("hello world", &ctx).unwrap(), "hello world");
         assert_eq!(&*render("hello {world", &ctx).unwrap(), "hello {world");
@@ -431,14 +424,20 @@ mod tests {
 
     #[test]
     fn test_render_etags() {
-        let ctx = Planet { name: "world".to_string(), info: None };
+        let ctx = Planet {
+            name: "world".to_string(),
+            info: None,
+        };
 
         assert_eq!(&*render("hello {{name}}", &ctx).unwrap(), "hello world");
     }
 
     #[test]
     fn test_render_utags() {
-        let ctx = Planet { name: "world".to_string(), info: None };
+        let ctx = Planet {
+            name: "world".to_string(),
+            info: None,
+        };
 
         assert_eq!(&*render("hello {{{name}}}", &ctx).unwrap(), "hello world");
 
@@ -448,22 +447,34 @@ mod tests {
     #[test]
     fn test_render_option() {
         let template = "{{name}}, {{age}}";
-        let ctx = Person { name: "Dennis".to_string(), age: None };
+        let ctx = Person {
+            name: "Dennis".to_string(),
+            age: None,
+        };
 
         assert_eq!(&*render(template, &ctx).unwrap(), "Dennis, ");
 
-        let ctx = Person { name: "Dennis".to_string(), age: Some(42) };
+        let ctx = Person {
+            name: "Dennis".to_string(),
+            age: Some(42),
+        };
         assert_eq!(&*render(template, &ctx).unwrap(), "Dennis, 42");
     }
 
     #[test]
     fn test_render_option_sections_implicit() {
         let template = "{{name}}, {{#age}}{{.}}{{/age}}{{^age}}No age{{/age}}";
-        let ctx = Person { name: "Dennis".to_string(), age: None };
+        let ctx = Person {
+            name: "Dennis".to_string(),
+            age: None,
+        };
 
         assert_eq!(&*render(template, &ctx).unwrap(), "Dennis, No age");
 
-        let ctx = Person { name: "Dennis".to_string(), age: Some(42) };
+        let ctx = Person {
+            name: "Dennis".to_string(),
+            age: Some(42),
+        };
         assert_eq!(&*render(template, &ctx).unwrap(), "Dennis, 42");
     }
 
@@ -471,7 +482,9 @@ mod tests {
     #[should_panic(message="nested Option types are not supported")]
     fn test_render_option_nested() {
         #[derive(RustcEncodable)]
-        struct Nested { opt: Option<Option<u32>> }
+        struct Nested {
+            opt: Option<Option<u32>>,
+        }
 
         let template = "-{{opt}}+";
         let ctx = Nested { opt: None };
@@ -486,20 +499,25 @@ mod tests {
 
     #[test]
     fn test_render_option_complex() {
-        let template = "{{name}} - \
-                        {{#info}}{{description}}; \
-                        It's moons are [{{#moons}}{{.}}{{/moons}}] \
-                        and has a population of {{population}}{{/info}}\
-                        {{^info}}No additional info{{/info}}";
-        let ctx = Planet { name: "Jupiter".to_string(), info: None };
-        assert_eq!(&*render(template, &ctx).unwrap(), "Jupiter - No additional info");
+        let template = "{{name}} - {{#info}}{{description}}; It's moons are \
+                        [{{#moons}}{{.}}{{/moons}}] and has a population of \
+                        {{population}}{{/info}}{{^info}}No additional info{{/info}}";
+        let ctx = Planet {
+            name: "Jupiter".to_string(),
+            info: None,
+        };
+        assert_eq!(&*render(template, &ctx).unwrap(),
+                   "Jupiter - No additional info");
 
         let address = PlanetInfo {
             moons: vec!["Luna".to_string()],
             population: 7300000000,
             description: "Birthplace of rust-lang".to_string(),
         };
-        let ctx = Planet { name: "Earth".to_string(), info: Some(address) };
+        let ctx = Planet {
+            name: "Earth".to_string(),
+            info: Some(address),
+        };
         assert_eq!(&*render(template, &ctx).unwrap(),
                    "Earth - Birthplace of rust-lang; It's moons are [Luna] and \
                    has a population of 7300000000");
@@ -529,18 +547,19 @@ mod tests {
 
         let mut ctx0 = HashMap::new();
         let ctx1 = HashMap::new();
-        ctx0.insert("a".to_string(), VecVal(vec!(Map(ctx1))));
+        ctx0.insert("a".to_string(), VecVal(vec![Map(ctx1)]));
 
         assert_eq!(render_data(&template, &Map(ctx0)), "01  35".to_string());
 
         let mut ctx0 = HashMap::new();
         let mut ctx1 = HashMap::new();
         ctx1.insert("n".to_string(), StrVal("a".to_string()));
-        ctx0.insert("a".to_string(), VecVal(vec!(Map(ctx1))));
+        ctx0.insert("a".to_string(), VecVal(vec![Map(ctx1)]));
         assert_eq!(render_data(&template, &Map(ctx0)), "01 a 35".to_string());
 
         let mut ctx = HashMap::new();
-        ctx.insert("a".to_string(), Fun(RefCell::new(Box::new(|_text| { "foo".to_string() }))));
+        ctx.insert("a".to_string(),
+                   Fun(RefCell::new(Box::new(|_text| "foo".to_string()))));
         assert_eq!(render_data(&template, &Map(ctx)), "0foo5".to_string());
     }
 
@@ -552,53 +571,53 @@ mod tests {
         assert_eq!(render_data(&template, &Map(ctx)), "01 35".to_string());
 
         let mut ctx = HashMap::new();
-        ctx.insert("a".to_string(), VecVal(vec!()));
+        ctx.insert("a".to_string(), VecVal(vec![]));
         assert_eq!(render_data(&template, &Map(ctx)), "01 35".to_string());
 
         let mut ctx0 = HashMap::new();
         let ctx1 = HashMap::new();
-        ctx0.insert("a".to_string(), VecVal(vec!(Map(ctx1))));
+        ctx0.insert("a".to_string(), VecVal(vec![Map(ctx1)]));
         assert_eq!(render_data(&template, &Map(ctx0)), "05".to_string());
 
         let mut ctx0 = HashMap::new();
         let mut ctx1 = HashMap::new();
         ctx1.insert("n".to_string(), StrVal("a".to_string()));
-        ctx0.insert("a".to_string(), VecVal(vec!(Map(ctx1))));
+        ctx0.insert("a".to_string(), VecVal(vec![Map(ctx1)]));
         assert_eq!(render_data(&template, &Map(ctx0)), "05".to_string());
     }
 
     fn assert_partials_data(template: Template) {
         let ctx = HashMap::new();
-        assert_eq!(render_data(&template, &Map(ctx)), "<h2>Names</h2>\n".to_string());
+        assert_eq!(render_data(&template, &Map(ctx)),
+                   "<h2>Names</h2>\n".to_string());
 
         let mut ctx = HashMap::new();
-        ctx.insert("names".to_string(), VecVal(vec!()));
-        assert_eq!(render_data(&template, &Map(ctx)), "<h2>Names</h2>\n".to_string());
+        ctx.insert("names".to_string(), VecVal(vec![]));
+        assert_eq!(render_data(&template, &Map(ctx)),
+                   "<h2>Names</h2>\n".to_string());
 
         let mut ctx0 = HashMap::new();
         let ctx1 = HashMap::new();
-        ctx0.insert("names".to_string(), VecVal(vec!(Map(ctx1))));
-        assert_eq!(
-            render_data(&template, &Map(ctx0)),
-            "<h2>Names</h2>\n  <strong></strong>\n\n".to_string());
+        ctx0.insert("names".to_string(), VecVal(vec![Map(ctx1)]));
+        assert_eq!(render_data(&template, &Map(ctx0)),
+                   "<h2>Names</h2>\n  <strong></strong>\n\n".to_string());
 
         let mut ctx0 = HashMap::new();
         let mut ctx1 = HashMap::new();
         ctx1.insert("name".to_string(), StrVal("a".to_string()));
-        ctx0.insert("names".to_string(), VecVal(vec!(Map(ctx1))));
-        assert_eq!(
-            render_data(&template, &Map(ctx0)),
-            "<h2>Names</h2>\n  <strong>a</strong>\n\n".to_string());
+        ctx0.insert("names".to_string(), VecVal(vec![Map(ctx1)]));
+        assert_eq!(render_data(&template, &Map(ctx0)),
+                   "<h2>Names</h2>\n  <strong>a</strong>\n\n".to_string());
 
         let mut ctx0 = HashMap::new();
         let mut ctx1 = HashMap::new();
         ctx1.insert("name".to_string(), StrVal("a".to_string()));
         let mut ctx2 = HashMap::new();
         ctx2.insert("name".to_string(), StrVal("<b>".to_string()));
-        ctx0.insert("names".to_string(), VecVal(vec!(Map(ctx1), Map(ctx2))));
-        assert_eq!(
-            render_data(&template, &Map(ctx0)),
-            "<h2>Names</h2>\n  <strong>a</strong>\n\n  <strong>&lt;b&gt;</strong>\n\n".to_string());
+        ctx0.insert("names".to_string(), VecVal(vec![Map(ctx1), Map(ctx2)]));
+        assert_eq!(render_data(&template, &Map(ctx0)),
+                   "<h2>Names</h2>\n  <strong>a</strong>\n\n  <strong>&lt;b&gt;</strong>\n\n"
+                       .to_string());
     }
 
     #[test]
@@ -617,15 +636,14 @@ mod tests {
         let path = PathBuf::from(src);
         let mut file_contents = vec![];
         match File::open(&path).and_then(|mut f| f.read_to_end(&mut file_contents)) {
-            Ok(_) => {},
+            Ok(_) => {}
             Err(e) => panic!("Could not read file {}", e),
         };
 
-        let s = String::from_utf8(file_contents.to_vec())
-                     .ok().expect("File was not UTF8 encoded");
+        let s = String::from_utf8(file_contents.to_vec()).ok().expect("File was not UTF8 encoded");
 
         match Json::from_str(&s) {
-            Err(e) =>  panic!("{:?}", e),
+            Err(e) => panic!("{:?}", e),
             Ok(json) => {
                 match json {
                     Json::Object(d) => {
@@ -648,12 +666,14 @@ mod tests {
                     match value {
                         &Json::String(ref s) => {
                             let path = tmpdir.join(&(key.clone() + ".mustache"));
-                            File::create(&path).and_then(|mut f| f.write_all(s.as_bytes())).unwrap();
+                            File::create(&path)
+                                .and_then(|mut f| f.write_all(s.as_bytes()))
+                                .unwrap();
                         }
                         _ => panic!(),
                     }
                 }
-            },
+            }
             _ => panic!(),
         }
     }
@@ -678,7 +698,7 @@ mod tests {
 
         match test.get(&"partials".to_string()) {
             Some(value) => write_partials(tmpdir.path(), value),
-            None => {},
+            None => {}
         }
 
         let ctx = Context::new(tmpdir.path().to_path_buf());
@@ -686,8 +706,10 @@ mod tests {
         let result = render_data(&template, &data);
 
         if result != expected {
-            println!("desc:     {}", test.get(&"desc".to_string()).unwrap().to_string());
-            println!("context:  {}", test.get(&"data".to_string()).unwrap().to_string());
+            println!("desc:     {}",
+                     test.get(&"desc".to_string()).unwrap().to_string());
+            println!("context:  {}",
+                     test.get(&"data".to_string()).unwrap().to_string());
             println!("=>");
             println!("template: {:?}", template);
             println!("expected: {}", expected);
@@ -752,12 +774,12 @@ mod tests {
         for json in parse_spec_tests("spec/specs/~lambdas.json").into_iter() {
             let mut test = match json {
                 Json::Object(m) => m,
-                value => { panic!("{}", value) }
+                value => panic!("{}", value),
             };
 
             let s = match test.remove(&"name".to_string()) {
                 Some(Json::String(s)) => s,
-                value => { panic!("{:?}", value) }
+                value => panic!("{:?}", value),
             };
 
             // Replace the lambda with rust code.
@@ -779,30 +801,30 @@ mod tests {
 
             match &*s {
                 "Interpolation" => {
-                    let f = |_text| { "world".to_string() };
+                    let f = |_text| "world".to_string();
                     ctx.insert("lambda".to_string(), Fun(RefCell::new(Box::new(f))));
-                },
+                }
                 "Interpolation - Expansion" => {
-                    let f = |_text| { "{{planet}}".to_string() };
+                    let f = |_text| "{{planet}}".to_string();
                     ctx.insert("lambda".to_string(), Fun(RefCell::new(Box::new(f))));
-                },
+                }
                 "Interpolation - Alternate Delimiters" => {
-                    let f = |_text| { "|planet| => {{planet}}".to_string() };
+                    let f = |_text| "|planet| => {{planet}}".to_string();
                     ctx.insert("lambda".to_string(), Fun(RefCell::new(Box::new(f))));
-                },
+                }
                 "Interpolation - Multiple Calls" => {
                     let f = move |_text: String| {
                         calls += 1;
                         calls.to_string()
                     };
                     ctx.insert("lambda".to_string(), Fun(RefCell::new(Box::new(f))));
-                },
+                }
                 "Escaping" => {
-                    let f = |_text| { ">".to_string() };
+                    let f = |_text| ">".to_string();
                     ctx.insert("lambda".to_string(), Fun(RefCell::new(Box::new(f))));
-                },
+                }
                 "Section" => {
-                    let f = | text: String| {
+                    let f = |text: String| {
                         if text == "{{x}}" {
                             "yes".to_string()
                         } else {
@@ -810,24 +832,24 @@ mod tests {
                         }
                     };
                     ctx.insert("lambda".to_string(), Fun(RefCell::new(Box::new(f))));
-                },
+                }
                 "Section - Expansion" => {
-                    let f = | text: String| { text.clone() + "{{planet}}" + &text };
+                    let f = |text: String| text.clone() + "{{planet}}" + &text;
                     ctx.insert("lambda".to_string(), Fun(RefCell::new(Box::new(f))));
-                },
+                }
                 "Section - Alternate Delimiters" => {
-                    let f = | text: String| { text.clone() + "{{planet}} => |planet|" + &text };
+                    let f = |text: String| text.clone() + "{{planet}} => |planet|" + &text;
                     ctx.insert("lambda".to_string(), Fun(RefCell::new(Box::new(f))));
-                },
+                }
                 "Section - Multiple Calls" => {
-                    let f = | text: String| { "__".to_string() + &text + "__" };
+                    let f = |text: String| "__".to_string() + &text + "__";
                     ctx.insert("lambda".to_string(), Fun(RefCell::new(Box::new(f))));
-                },
+                }
                 "Inverted Section" => {
-                    let f= |_text| { "".to_string() };
+                    let f = |_text| "".to_string();
                     ctx.insert("lambda".to_string(), Fun(RefCell::new(Box::new(f))));
-                },
-                value => { panic!("{}", value) }
+                }
+                value => panic!("{}", value),
             };
 
             run_test(test, Map(ctx));

--- a/src/template.rs
+++ b/src/template.rs
@@ -73,10 +73,10 @@ impl<'a> RenderContext<'a> {
             Text(ref value) => {
                 self.render_text(wr, value)
             }
-            ETag(ref path, _) => {
+            EscapedTag(ref path, _) => {
                 self.render_etag(wr, stack, path)
             }
-            UTag(ref path, _) => {
+            UnescapedTag(ref path, _) => {
                 self.render_utag(wr, stack, path)
             }
             Section(ref path, true, ref children, _, _, _, _, _) => {

--- a/src/template.rs
+++ b/src/template.rs
@@ -390,7 +390,7 @@ mod tests {
     use rustc_serialize::{json, Encodable};
     use rustc_serialize::json::Json;
 
-    use encoder::Encoder;
+    use encoder;
     use Error;
 
     use super::super::{Data, StrVal, VecVal, Map, Fun};
@@ -749,12 +749,9 @@ mod tests {
             let test = assert_let!(Json::Object(m) = json => m);
 
             let data = test.get("data").expect("No test data").clone();
+            let data = encoder::encode(&data).expect("Failed to encode");
 
-            let mut encoder = Encoder::new();
-            data.encode(&mut encoder).expect("Failed to encode");
-            assert_eq!(encoder.data.len(), 1);
-
-            run_test(test, encoder.data.pop().expect("Failed to pop data"));
+            run_test(test, data);
         }
     }
 
@@ -798,10 +795,9 @@ mod tests {
             // Replace the lambda with rust code.
             let data = test.remove("data").expect("No test data");
 
-            let mut encoder = Encoder::new();
-            data.encode(&mut encoder).expect("Failed to encode");
+            let data = encoder::encode(&data).expect("Failed to encode");
 
-            let mut ctx = assert_let!(Some(Map(ctx)) = encoder.data.pop() => ctx);
+            let mut ctx = assert_let!(Map(ctx) = data => ctx);
 
             // needed for the closure test.
             let mut calls = 0usize;

--- a/src/template.rs
+++ b/src/template.rs
@@ -390,7 +390,8 @@ mod tests {
     use rustc_serialize::{json, Encodable};
     use rustc_serialize::json::Json;
 
-    use encoder::{Encoder, Error};
+    use encoder::Encoder;
+    use Error;
 
     use super::super::{Data, StrVal, VecVal, Map, Fun};
     use super::super::{Context, Template};

--- a/src/template.rs
+++ b/src/template.rs
@@ -88,7 +88,9 @@ impl<'a> RenderContext<'a> {
             Partial(ref name, ref indent, _) => {
                 self.render_partial(wr, stack, name, indent)
             }
-            _ => panic!(),
+            IncompleteSection(..) => {
+                bug!("render_token should not encounter IncompleteSections")
+            }
         }
     }
 
@@ -206,7 +208,7 @@ impl<'a> RenderContext<'a> {
                     }
 
                     ref value => {
-                        panic!("unexpected value {:?}", value);
+                        bug!("render_utag: unexpected value {:?}", value);
                     }
                 }
             }
@@ -273,7 +275,7 @@ impl<'a> RenderContext<'a> {
                             stack.pop();
                         }
                     }
-                    _ => panic!("unexpected value {:?}", value),
+                    _ => bug!("unexpected value {:?}", value),
                 }
             }
         };
@@ -342,7 +344,7 @@ impl<'a> RenderContext<'a> {
                         break;
                     }
                 }
-                _ => panic!("expect map: {:?}", path),
+                _ => bug!("expect map: {:?}", path),
             }
         }
 


### PR DESCRIPTION
This should remove runtime panics in most cases, there are a few `bug!` panics remaining but if they fire it's likely a logic error in mustache itself rather than a data problem and should be logged & fixed.

Issue #29 calls for returning `io::Error` specifically, but since a Template could invoke a closure which would need to compile the returned (String) Template there are more failure conditions than just the IO cases. It should be possible to `map_err` to reduce to `io::Error` if required.