### PR TITLE
docs(*): fix docs link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ cargo test
 [2]: http://www.ivan.fomichev.name/2008/05/erlang-template-engine-prototype.html
 [3]: https://mustache.github.io/
 [4]: http://mustache.github.com/mustache.5.html
-[5]: http://nickel-org.github.io/rust-mustache
+[5]: http://nickel.rs/rust-mustache/mustache/index.html
 
 # License
 


### PR DESCRIPTION
The current link in the Readme *does* work but since there was a redirect on this specific url to the broken mustache.nickel.rs, changing the link to the new location helps people with an infected cache (like me!) due to the *permanent* 301 which their isp may have intercepted.