### PR TITLE
feat(serde): add support for Serde serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,5 @@ env:
   global:
     secure: dKGat/Zb9K7hjdKnQGeKIDlBkBPA+vGZsc9h43WC9SyCQM8srwg2+A0q/Bu59T35BuTXoT1J1mo4f5HztTK0cRS3eJX6nBflTy7g/mrkrsTT8wYNfcZUu0FyXV8xozOohBXW4xMSSLUmaz3VGrbWrHH31Wb8RexVBDmWWGyv810=
   matrix:
-    - FEATURES="--features serde"
+    - FEATURES="--features test-serde"
     - FEATURES=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,27 @@ cache:
     - target
 
 rust:
-- 1.4.0
 - stable
 - nightly
 - beta
+
+matrix:
+    include:
+          - rust: 1.4.0 # minimum supported rustc version
+            env: FEATURES="" # don't test serde on 1.4.0
 
 before_script:
 - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 
 script:
 - |
-    travis-cargo build &&
-    travis-cargo test &&
+    travis-cargo build -- $FEATURES &&
+    travis-cargo test -- $FEATURES &&
     travis-cargo doc &&
-    echo "Testing README" &&
-    rustdoc --test README.md -L dependency=./target/debug/deps --extern mustache=./target/debug/libmustache.rlib --extern rustc_serialize=./target/debug/deps/librustc_serialize
+    if [ -z $FEATURES ]; then
+        echo "Testing README" &&
+        rustdoc --test README.md -L dependency=./target/debug/deps --extern mustache=./target/debug/libmustache.rlib --extern rustc_serialize=./target/debug/deps/librustc_serialize
+    fi
 
 after_success:
 - |
@@ -29,3 +35,6 @@ after_success:
 env:
   global:
     secure: dKGat/Zb9K7hjdKnQGeKIDlBkBPA+vGZsc9h43WC9SyCQM8srwg2+A0q/Bu59T35BuTXoT1J1mo4f5HztTK0cRS3eJX6nBflTy7g/mrkrsTT8wYNfcZUu0FyXV8xozOohBXW4xMSSLUmaz3VGrbWrHH31Wb8RexVBDmWWGyv810=
+  matrix:
+    - FEATURES="--features serde"
+    - FEATURES=""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ test-serde = ["serde", "serde_json", "serde_codegen"]
 [dependencies]
 rustc-serialize = "0.3.18"
 log = "0.3.5"
-serde = { version = "0.7", optional = true }
-serde_json = { version = "0.7", optional = true }
+serde = { version = "0.8", optional = true }
+serde_json = { version = "0.8", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3.4"
 
 [build-dependencies]
-serde_codegen = { version = "0.7", optional = true }
+serde_codegen = { version = "0.8", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,16 @@ build = "build.rs"
 
 [features]
 unstable = []
+test-serde = ["serde", "serde_json", "serde_codegen"]
 
 [dependencies]
 rustc-serialize = "0.3.18"
 log = "0.3.5"
-serde = { optional = true, version = "0.7" }
+serde = { version = "0.7", optional = true }
+serde_json = { version = "0.7", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3.4"
-serde_json = "0.7"
 
 [build-dependencies]
-serde_codegen = "0.7"
+serde_codegen = { version = "0.7", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,19 @@ version = "0.8.0"
 authors = ["erick.tryzelaar@gmail.com"]
 license = "MIT/Apache-2.0"
 
+build = "build.rs"
+
 [features]
 unstable = []
 
 [dependencies]
 rustc-serialize = "0.3.18"
 log = "0.3.5"
+serde = { optional = true, version = "0.7" }
 
 [dev-dependencies]
 tempdir = "0.3.4"
+serde_json = "0.7"
+
+[build-dependencies]
+serde_codegen = "0.7"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,11 @@
+#[cfg(feature = "test-serde")]
 extern crate serde_codegen;
 
-use std::env;
-use std::path::Path;
-
+#[cfg(feature = "test-serde")]
 pub fn main() {
+    use std::env;
+    use std::path::Path;
+
     let out_dir = env::var_os("OUT_DIR").unwrap();
 
     let src = Path::new("src/test_codegen.rs.in");
@@ -11,3 +13,6 @@ pub fn main() {
 
     serde_codegen::expand(&src, &dst).unwrap();
 }
+
+#[cfg(not(feature = "test-serde"))]
+fn main() {}

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+extern crate serde_codegen;
+
+use std::env;
+use std::path::Path;
+
+pub fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+
+    let src = Path::new("src/test_codegen.rs.in");
+    let dst = Path::new(&out_dir).join("test_codegen.rs");
+
+    serde_codegen::expand(&src, &dst).unwrap();
+}

--- a/examples/vector_iteration.rs
+++ b/examples/vector_iteration.rs
@@ -1,12 +1,26 @@
+#[cfg(feature = "serde")]
+extern crate serde;
+
+#[cfg(not(feature = "serde"))]
 extern crate rustc_serialize;
 extern crate mustache;
 
 use std::str;
 use std::collections::HashMap;
 
-#[derive(RustcEncodable)]
+#[cfg_attr(not(feature = "serde"), derive(RustcEncodable))]
 struct User {
     name: String
+}
+
+#[cfg(feature = "serde")]
+impl serde::ser::Serialize for User {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+    where S: serde::ser::Serializer {
+        let mut map = HashMap::new();
+        map.insert("name", &self.name);
+        map.serialize(serializer)
+    }
 }
 
 fn main() {
@@ -27,5 +41,7 @@ fn main() {
     let mut bytes = vec![];
     template.render(&mut bytes, &data).expect("Failed to render");
 
-    assert_eq!(str::from_utf8(&bytes), Ok("Hello Harry!\nHello Samantha!\n"))
+    let string = str::from_utf8(&bytes);
+    assert_eq!(string, Ok("Hello Harry!\nHello Samantha!\n"));
+    println!("{}", string.unwrap());
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,8 @@
 use std::cell::RefCell;
 use std::string::ToString;
 use std::collections::HashMap;
-use rustc_serialize::Encodable;
+
+use encoder::Encodable;
 
 use encoder;
 use encoder::Error;

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -1,0 +1,186 @@
+use std::fmt;
+use std::error;
+
+use super::{Data, StrVal};
+use self::Error::*;
+
+#[cfg(feature = "serde")]
+mod serialization {
+    mod serde;
+    pub use serde::Serialize as Encodable;
+}
+
+#[cfg(not(feature = "serde"))]
+mod serialization {
+    mod rustc_serialize;
+    pub use rustc_serialize::Encodable;
+}
+
+/// Shared reexport between serde and rustc_serialize.
+///
+/// It shares a name so that projects can refer to a single trait bound
+/// while maintaining compatability with both serialization libraries.
+pub use self::serialization::Encodable;
+
+#[derive(Default)]
+pub struct Encoder {
+     data: Vec<Data>,
+}
+
+impl Encoder {
+    pub fn new() -> Encoder {
+        Encoder::default()
+    }
+
+    pub fn stack(&self) -> &[Data] {
+        &self.data
+    }
+}
+
+/// Error type to represent encoding failure.
+///
+/// This type is not intended to be matched exhaustively as new variants
+/// may be added in future without a version bump.
+#[derive(Debug)]
+pub enum Error {
+    NestedOptions,
+    UnsupportedType,
+    MissingElements,
+    KeyIsNotString,
+    NoDataToEncode,
+    MultipleRootsFound,
+
+    /// This variant is currently only used by serde.
+    Serialization(String),
+
+    #[doc(hidden)]
+    __Nonexhaustive,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::error::Error;
+        self.description().fmt(f)
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            NestedOptions => "nested Option types are not supported",
+            UnsupportedType => "unsupported type",
+            MissingElements => "no elements in value",
+            KeyIsNotString => "key is not a string",
+            NoDataToEncode => "the encodable type created no data",
+            MultipleRootsFound => {
+                "the encodable type emitted data that was not tree-like in structure"
+            }
+            Serialization(ref e) => e,
+            Error::__Nonexhaustive => unreachable!(),
+        }
+    }
+}
+
+pub type EncoderResult = Result<(), Error>;
+
+impl Encoder {
+    fn push(&mut self, data: Data) {
+        self.data.push(data);
+    }
+
+    fn push_ok(&mut self, data: Data) -> EncoderResult {
+        self.push(data);
+        Ok(())
+    }
+
+    fn push_str_ok<T: ToString>(&mut self, data: T) -> EncoderResult {
+        self.push(StrVal(data.to_string()));
+        Ok(())
+    }
+}
+
+#[cfg(feature = "serde")]
+pub fn encode<T: Encodable>(data: &T) -> Result<Data, Error> {
+    let mut encoder = Encoder::new();
+    try!(data.serialize(&mut encoder));
+    match encoder.data.len() {
+        1 => Ok(encoder.data.pop().unwrap()),
+        // These two errors are really down to either the type implementing Encodable wrong
+        // or using some data which is incompatible with the way mustache *currently* works.
+        // It does feel like `bug!` more than Error but maybe it covers some usecases so
+        // lets not panic here.
+        0 => Err(NoDataToEncode),
+        _ => Err(MultipleRootsFound),
+    }
+}
+
+#[cfg(not(feature = "serde"))]
+pub fn encode<T: Encodable>(data: &T) -> Result<Data, Error> {
+    let mut encoder = Encoder::new();
+    try!(data.encode(&mut encoder));
+    match encoder.data.len() {
+        1 => Ok(encoder.data.pop().unwrap()),
+        // These two errors are really down to either the type implementing Encodable wrong
+        // or using some data which is incompatible with the way mustache *currently* works.
+        // It does feel like `bug!` more than Error but maybe it covers some usecases so
+        // lets not panic here.
+        0 => Err(NoDataToEncode),
+        _ => Err(MultipleRootsFound),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{encode, Error};
+
+    struct NoData;
+    struct Multiroot;
+
+    #[test]
+    fn encodable_with_no_data() {
+        assert_let!(Err(Error::NoDataToEncode) = encode(&NoData));
+    }
+
+    #[test]
+    fn encodable_with_multiple_roots() {
+        assert_let!(Err(Error::MultipleRootsFound) = encode(&Multiroot));
+    }
+
+    #[cfg(not(feature = "serde"))]
+    mod serialization {
+        use super::{NoData, Multiroot};
+        use rustc_serialize::{Encodable, Encoder};
+
+        impl Encodable for NoData {
+            fn encode<S: Encoder>(&self, _: &mut S) -> Result<(), S::Error> {
+                Ok(())
+            }
+        }
+
+        impl Encodable for Multiroot {
+            fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+                try!(s.emit_u32(4));
+                s.emit_u32(1)
+            }
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    mod serialization {
+        use super::{NoData, Multiroot};
+        use serde::ser::{Serialize, Serializer};
+
+        impl Serialize for NoData {
+            fn serialize<S: Serializer>(&self, _: &mut S) -> Result<(), S::Error> {
+                Ok(())
+            }
+        }
+
+        impl Serialize for Multiroot {
+            fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), S::Error> {
+                try!(s.serialize_u32(4));
+                s.serialize_u32(1)
+            }
+        }
+    }
+}

--- a/src/encoder/serialization/rustc_serialize.rs
+++ b/src/encoder/serialization/rustc_serialize.rs
@@ -1,83 +1,10 @@
 use std::collections::HashMap;
-use std::fmt;
-use std::error;
 use rustc_serialize;
+use {StrVal, Bool, VecVal, Map, OptVal};
+use encoder::{Encoder, EncoderResult, Error};
+use encoder::Error::*;
 
-use super::{Data, StrVal, Bool, VecVal, Map, OptVal};
-use self::Error::*;
-
-#[derive(Default)]
-pub struct Encoder {
-     data: Vec<Data>,
-}
-
-impl Encoder {
-    pub fn new() -> Encoder {
-        Encoder::default()
-    }
-
-    pub fn stack(&self) -> &[Data] {
-        &self.data
-    }
-}
-
-/// Error type to represent encoding failure.
-///
-/// This type is not intended to be matched exhaustively as new variants
-/// may be added in future without a version bump.
-#[derive(Debug)]
-pub enum Error {
-    NestedOptions,
-    UnsupportedType,
-    MissingElements,
-    KeyIsNotString,
-    NoDataToEncode,
-    MultipleRootsFound,
-
-    #[doc(hidden)]
-    __Nonexhaustive,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::error::Error;
-        self.description().fmt(f)
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            NestedOptions => "nested Option types are not supported",
-            UnsupportedType => "unsupported type",
-            MissingElements => "no elements in value",
-            KeyIsNotString => "key is not a string",
-            NoDataToEncode => "the encodable type created no data",
-            MultipleRootsFound => {
-                "the encodable type emitted data that was not tree-like in structure"
-            }
-            Error::__Nonexhaustive => unreachable!(),
-        }
-    }
-}
-
-pub type EncoderResult = Result<(), Error>;
-
-impl Encoder {
-    fn push(&mut self, data: Data) {
-        self.data.push(data);
-    }
-
-    fn push_ok(&mut self, data: Data) -> EncoderResult {
-        self.push(data);
-        Ok(())
-    }
-
-    fn push_str_ok<T: ToString>(&mut self, data: T) -> EncoderResult {
-        self.push(StrVal(data.to_string()));
-        Ok(())
-    }
-}
+pub use rustc_serialize::Encodable as Encodable;
 
 impl rustc_serialize::Encoder for Encoder {
     type Error = Error;
@@ -322,52 +249,5 @@ impl rustc_serialize::Encoder for Encoder {
         m.insert(k, popped);
         self.push(Map(m));
         Ok(())
-    }
-}
-
-pub fn encode<T: rustc_serialize::Encodable>(data: &T) -> Result<Data, Error> {
-    let mut encoder = Encoder::new();
-    try!(data.encode(&mut encoder));
-    match encoder.data.len() {
-        1 => Ok(encoder.data.pop().unwrap()),
-        // These two errors are really down to either the type implementing Encodable wrong
-        // or using some data which is incompatible with the way mustache *currently* works.
-        // It does feel like `bug!` more than Error but maybe it covers some usecases so
-        // lets not panic here.
-        0 => Err(NoDataToEncode),
-        _ => Err(MultipleRootsFound),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{encode, Error};
-    use rustc_serialize::{Encodable, Encoder};
-
-    struct NoData;
-
-    impl Encodable for NoData {
-        fn encode<S: Encoder>(&self, _: &mut S) -> Result<(), S::Error> {
-            Ok(())
-        }
-    }
-
-    struct Multiroot;
-
-    impl Encodable for Multiroot {
-        fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-            try!(s.emit_u32(4));
-            s.emit_u32(1)
-        }
-    }
-
-    #[test]
-    fn encodable_with_no_data() {
-        assert_let!(Err(Error::NoDataToEncode) = encode(&NoData));
-    }
-
-    #[test]
-    fn encodable_with_multiple_roots() {
-        assert_let!(Err(Error::MultipleRootsFound) = encode(&Multiroot));
     }
 }

--- a/src/encoder/serialization/serde.rs
+++ b/src/encoder/serialization/serde.rs
@@ -1,0 +1,129 @@
+use std::collections::HashMap;
+use serde;
+use {StrVal, Bool, VecVal, Map, OptVal};
+use encoder::{Encoder, EncoderResult, Error};
+use encoder::Error::*;
+
+pub use serde::Serialize as Encodable;
+
+impl serde::ser::Error for Error {
+    fn custom<T: Into<String>>(msg: T) -> Self {
+        Error::Serialization(msg.into())
+    }
+}
+
+impl serde::Serializer for Encoder {
+    type Error = Error;
+
+    fn serialize_bool(&mut self, v: bool) -> EncoderResult {
+        self.push_ok(Bool(v))
+    }
+
+    fn serialize_i64(&mut self, v: i64) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_u64(&mut self, v: u64) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_f64(&mut self, v: f64) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_str(&mut self, v: &str) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_unit(&mut self) -> EncoderResult {
+        Err(UnsupportedType)
+    }
+
+    fn serialize_none(&mut self) -> EncoderResult {
+        self.push_ok(OptVal(None))
+    }
+
+    fn serialize_some<V>(&mut self, value: V) -> EncoderResult
+    where V: serde::ser::Serialize
+    {
+        try!(value.serialize(self));
+
+        let val = match self.data.pop() {
+            Some(OptVal(_)) => return Err(NestedOptions),
+            Some(d) => d,
+            _ => {
+                return Err(UnsupportedType);
+            }
+        };
+        self.push_ok(OptVal(Some(Box::new(val))))
+    }
+
+    fn serialize_seq<V>(&mut self, mut visitor: V) -> EncoderResult
+    where V: serde::ser::SeqVisitor {
+        let len = visitor.len().unwrap_or(0);
+        self.push(VecVal(Vec::with_capacity(len)));
+
+        while let Some(()) = try!(visitor.visit(self)) {}
+
+        Ok(())
+    }
+
+    fn serialize_seq_elt<T>(&mut self, value: T) -> EncoderResult
+    where T: serde::ser::Serialize {
+        let mut v = match self.data.pop() {
+            Some(VecVal(v)) => v,
+            _ => {
+                return Err(UnsupportedType);
+            }
+        };
+        try!(value.serialize(self));
+        let data = match self.data.pop() {
+            Some(d) => d,
+            _ => {
+                return Err(UnsupportedType);
+            }
+        };
+        v.push(data);
+        self.push_ok(VecVal(v))
+    }
+
+    fn serialize_map<V>(&mut self, mut visitor: V) -> EncoderResult
+    where V: serde::ser::MapVisitor
+    {
+        let len = visitor.len().unwrap_or(0);
+
+        self.push(Map(HashMap::with_capacity(len)));
+
+        while let Some(()) = try!(visitor.visit(self)) {}
+
+        Ok(())
+    }
+
+    fn serialize_map_elt<K, V>(&mut self, key: K, value: V) -> EncoderResult
+    where K: serde::Serialize,
+          V: serde::Serialize
+    {
+        try!(key.serialize(self));
+        let key = match self.data.pop() {
+            Some(StrVal(s)) => s,
+            _ => {
+                return Err(KeyIsNotString);
+            }
+        };
+
+        let mut m = match self.data.pop() {
+            Some(Map(m)) => m,
+            _ => bug!("Expected a map"),
+        };
+
+        try!(value.serialize(self));
+
+        let value = match self.data.pop() {
+            Some(p) => p,
+            None => bug!("Nothing to pop!"),
+        };
+        m.insert(key, value);
+        self.push(Map(m));
+        Ok(())
+    }
+}

--- a/src/encoder/serialization/serde.rs
+++ b/src/encoder/serialization/serde.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 use serde;
-use {StrVal, Bool, VecVal, Map, OptVal};
+use {Data, StrVal, Bool, VecVal, Map, OptVal};
 use encoder::{Encoder, EncoderResult, Error};
 use encoder::Error::*;
+
+use serde::Serialize;
 
 pub use serde::Serialize as Encodable;
 
@@ -15,8 +17,50 @@ impl serde::ser::Error for Error {
 impl serde::Serializer for Encoder {
     type Error = Error;
 
+    // FIXME: Serialization could likely be made more efficient by taking advantage of
+    // better associated-types here.
+
+    // Sequence-like
+    type SeqState = Vec<Data>;
+    type TupleState = Self::SeqState;
+    type TupleStructState = Self::SeqState;
+    type TupleVariantState = Self::SeqState;
+
+    // Map-like
+    type MapState = HashMap<String, Data>;
+    type StructState = Self::MapState;
+    type StructVariantState = Self::MapState;
+
     fn serialize_bool(&mut self, v: bool) -> EncoderResult {
         self.push_ok(Bool(v))
+    }
+
+    fn serialize_char(&mut self, v: char) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_u8(&mut self, v: u8) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_i8(&mut self, v: i8) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_u16(&mut self, v: u16) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_i16(&mut self, v: i16) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_u32(&mut self, v: u32) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_i32(&mut self, v: i32) -> EncoderResult {
+        self.push_str_ok(v)
     }
 
     fn serialize_i64(&mut self, v: i64) -> EncoderResult {
@@ -24,6 +68,18 @@ impl serde::Serializer for Encoder {
     }
 
     fn serialize_u64(&mut self, v: u64) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_usize(&mut self, v: usize) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_isize(&mut self, v: isize) -> EncoderResult {
+        self.push_str_ok(v)
+    }
+
+    fn serialize_f32(&mut self, v: f32) -> EncoderResult {
         self.push_str_ok(v)
     }
 
@@ -35,6 +91,21 @@ impl serde::Serializer for Encoder {
         self.push_str_ok(v)
     }
 
+    fn serialize_unit_struct(&mut self, _name: &'static str) -> Result<(), Error> {
+        // FIXME: Perhaps this could be relaxed to just 'do nothing'
+        Err(UnsupportedType)
+    }
+
+    fn serialize_unit_variant(&mut self,
+                               _name: &'static str,
+                               _variant_index: usize,
+                               _variant: &'static str,
+                               ) -> Result<(), Self::Error>
+    {
+        // FIXME: Perhaps this could be relaxed to just 'do nothing'
+        Err(UnsupportedType)
+    }
+
     fn serialize_unit(&mut self) -> EncoderResult {
         Err(UnsupportedType)
     }
@@ -44,7 +115,7 @@ impl serde::Serializer for Encoder {
     }
 
     fn serialize_some<V>(&mut self, value: V) -> EncoderResult
-    where V: serde::ser::Serialize
+    where V: Serialize
     {
         try!(value.serialize(self));
 
@@ -58,24 +129,82 @@ impl serde::Serializer for Encoder {
         self.push_ok(OptVal(Some(Box::new(val))))
     }
 
-    fn serialize_seq<V>(&mut self, mut visitor: V) -> EncoderResult
-    where V: serde::ser::SeqVisitor {
-        let len = visitor.len().unwrap_or(0);
-        self.push(VecVal(Vec::with_capacity(len)));
-
-        while let Some(()) = try!(visitor.visit(self)) {}
-
-        Ok(())
+    fn serialize_struct(&mut self,
+                        _name: &'static str,
+                        len: usize) -> Result<Self::StructState, Error> {
+        self.serialize_map(Some(len))
     }
 
-    fn serialize_seq_elt<T>(&mut self, value: T) -> EncoderResult
-    where T: serde::ser::Serialize {
-        let mut v = match self.data.pop() {
-            Some(VecVal(v)) => v,
-            _ => {
-                return Err(UnsupportedType);
-            }
-        };
+    fn serialize_struct_elt<V>(&mut self,
+                               state: &mut Self::StructState,
+                               key: &'static str,
+                               value: V) -> Result<(), Error>
+    where V: Serialize {
+        try!(self.serialize_map_key(state, key));
+        self.serialize_map_value(state, value)
+    }
+
+    fn serialize_struct_end(&mut self, state: Self::StructState) -> Result<(), Error> {
+        self.serialize_map_end(state)
+    }
+
+    fn serialize_struct_variant(&mut self,
+                                _name: &'static str,
+                                _id: usize,
+                                _variant: &'static str,
+                                len: usize) -> Result<Self::StructVariantState, Error> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant_elt<V>(&mut self,
+                                       state: &mut Self::StructVariantState,
+                                       key: &'static str, value: V) -> Result<(), Error>
+    where V: Serialize {
+        try!(self.serialize_map_key(state, key));
+        self.serialize_map_value(state, value)
+    }
+
+    fn serialize_struct_variant_end(&mut self,
+                                    state: Self::StructVariantState) -> Result<(), Error> {
+        self.serialize_map_end(state)
+    }
+
+    fn serialize_newtype_struct<T: Serialize>(&mut self,
+                                          _name: &'static str,
+                                          value: T)
+                                          -> Result<(), Self::Error> {
+        // Ignore newtype name
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T: Serialize>(&mut self,
+                                           _name: &'static str,
+                                           _variant_index: usize,
+                                           _variant: &'static str,
+                                           value: T)
+                                           -> Result<(), Self::Error> {
+        // Ignore newtype name
+        value.serialize(self)
+    }
+
+    fn serialize_bytes(&mut self, v: &[u8]) -> Result<(), Error> {
+        let mut state = try!(self.serialize_seq(Some(v.len())));
+        for c in v {
+            try!(self.serialize_seq_elt(&mut state, c));
+        }
+        self.serialize_seq_end(state)
+    }
+
+    fn serialize_seq_fixed_size(&mut self, len: usize) -> Result<Self::SeqState, Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_seq(&mut self, len: Option<usize>) -> Result<Self::SeqState, Error> {
+        Ok(Vec::with_capacity(len.unwrap_or(0)))
+    }
+
+    fn serialize_seq_elt<T>(&mut self, state: &mut Self::SeqState, value: T) -> EncoderResult
+    where T: Serialize {
         try!(value.serialize(self));
         let data = match self.data.pop() {
             Some(d) => d,
@@ -83,27 +212,81 @@ impl serde::Serializer for Encoder {
                 return Err(UnsupportedType);
             }
         };
-        v.push(data);
-        self.push_ok(VecVal(v))
-    }
 
-    fn serialize_map<V>(&mut self, mut visitor: V) -> EncoderResult
-    where V: serde::ser::MapVisitor
-    {
-        let len = visitor.len().unwrap_or(0);
-
-        self.push(Map(HashMap::with_capacity(len)));
-
-        while let Some(()) = try!(visitor.visit(self)) {}
-
+        state.push(data);
         Ok(())
     }
 
-    fn serialize_map_elt<K, V>(&mut self, key: K, value: V) -> EncoderResult
-    where K: serde::Serialize,
-          V: serde::Serialize
-    {
-        try!(key.serialize(self));
+    fn serialize_seq_end(&mut self, state: Self::SeqState) -> Result<(), Error> {
+        self.push_ok(VecVal(state))
+    }
+
+    fn serialize_tuple(&mut self, len: usize) -> Result<Self::SeqState, Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_elt<T>(&mut self, state: &mut Self::SeqState, value: T) -> Result<(), Error>
+    where T: Serialize {
+        self.serialize_seq_elt(state, value)
+    }
+
+    fn serialize_tuple_end(&mut self, state: Self::SeqState) -> Result<(), Error> {
+        self.serialize_seq_end(state)
+    }
+
+    fn serialize_tuple_struct(&mut self,
+                              _name: &'static str,
+                              len: usize) -> Result<Self::SeqState, Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct_elt<T>(&mut self,
+                                     state: &mut Self::SeqState,
+                                     value: T) -> Result<(), Error>
+    where T: Serialize {
+        self.serialize_seq_elt(state, value)
+    }
+
+    fn serialize_tuple_struct_end(&mut self, state: Self::SeqState) -> Result<(), Error> {
+        self.serialize_seq_end(state)
+    }
+    fn serialize_tuple_variant(&mut self,
+                               _name: &'static str,
+                               _id: usize,
+                               _variant: &'static str,
+                               len: usize) -> Result<Self::SeqState, Error> {
+        self.serialize_seq(Some(len))
+    }
+    fn serialize_tuple_variant_elt<T>(&mut self,
+                                      state: &mut Self::SeqState,
+                                      value: T) -> Result<(), Error>
+    where T: serde::ser::Serialize {
+        self.serialize_seq_elt(state, value)
+    }
+    fn serialize_tuple_variant_end(&mut self, state: Self::SeqState) -> Result<(), Error> {
+        self.serialize_seq_end(state)
+    }
+
+    fn serialize_map(&mut self,
+                 len: Option<usize>)
+                 -> Result<Self::MapState, Self::Error> {
+        Ok(HashMap::with_capacity(len.unwrap_or(0)))
+    }
+
+    fn serialize_map_key<T: Serialize>(&mut self,
+                                   _state: &mut Self::MapState,
+                                   key: T)
+                                   -> Result<(), Self::Error> {
+        key.serialize(self)
+    }
+
+    fn serialize_map_value<T: Serialize>(&mut self,
+                                        state: &mut Self::MapState,
+                                        value: T)
+                                        -> Result<(), Self::Error> {
+        // FIXME: With the new serde API (0.8), `serialize_map_key` and `serialize_map_value` may
+        // have other method calls interleaved between them which will fail here or else give wrong
+        // results.
         let key = match self.data.pop() {
             Some(StrVal(s)) => s,
             _ => {
@@ -111,19 +294,20 @@ impl serde::Serializer for Encoder {
             }
         };
 
-        let mut m = match self.data.pop() {
-            Some(Map(m)) => m,
-            _ => bug!("Expected a map"),
-        };
-
         try!(value.serialize(self));
-
         let value = match self.data.pop() {
             Some(p) => p,
             None => bug!("Nothing to pop!"),
         };
-        m.insert(key, value);
-        self.push(Map(m));
+
+        state.insert(key, value);
+
         Ok(())
+    }
+
+    fn serialize_map_end(&mut self,
+                        state: Self::MapState)
+                        -> Result<(), Self::Error> {
+        self.push_ok(Map(state))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,13 @@
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 
+#[cfg(not(feature = "serde"))]
 extern crate rustc_serialize;
+#[cfg(feature = "serde")]
+extern crate serde;
+#[cfg(all(test, feature = "serde"))]
+extern crate serde_json;
+
 extern crate log;
 #[cfg(test)]
 extern crate tempdir;

--- a/src/test_codegen.rs.in
+++ b/src/test_codegen.rs.in
@@ -1,0 +1,23 @@
+#[derive(Serialize, Debug)]
+pub struct Planet {
+    pub name: String,
+    pub info: Option<PlanetInfo>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct PlanetInfo {
+    pub moons: Vec<String>,
+    pub population: u64,
+    pub description: String,
+}
+
+#[derive(Serialize, Debug)]
+pub struct Person {
+    pub name: String,
+    pub age: Option<u32>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct NestedOptions {
+    pub opt: Option<Option<u32>>,
+}


### PR DESCRIPTION
To use this feature, you can activate the serde feature:

``` toml
[dependencies.mustache]
version = "0.8"
features = ["serde"]
```

The minimum compiler version for the serde feature will track stable.

Closes #33.
