### PR TITLE
Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ git push --tags origin master
 [1]: http://code.google.com/p/google-ctemplate/
 [2]: http://www.ivan.fomichev.name/2008/05/erlang-template-engine-prototype.html
 [3]: https://mustache.github.io/
-[4]: http://mustache.github.com/mustache.5.html
+[4]: https://mustache.github.io/mustache.5.html
 [5]: https://docs.rs/mustache
 
 # License


### PR DESCRIPTION
The link to mustache documentation was previously broken, now it works.