### PR TITLE
replace tempdir with tempfile, as tempdir is deprecated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde = "1.0.0"
 [dev-dependencies]
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
-tempdir = "0.3.4"
+tempfile = "3.3.0"
 
 [[test]]
 name = "test"

--- a/tests/template.rs
+++ b/tests/template.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use tempdir::TempDir;
+use tempfile::TempDir;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::Write;
@@ -492,7 +492,7 @@ fn run_test(test: serde_json::Map<String, Json>, data: Data) {
 
     // Make a temporary dir where we'll store our partials. This is to
     // avoid a race on filenames.
-    let tmpdir = TempDir::new("").expect("Failed to make tempdir");
+    let tmpdir = TempDir::new().expect("Failed to make tempdir");
 
     if let Some(value) = test.get("partials") {
         write_partials(tmpdir.path(), value)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,7 @@
 extern crate mustache;
 extern crate serde;
 extern crate serde_json;
-extern crate tempdir;
+extern crate tempfile;
 
 #[macro_use] extern crate serde_derive;
 


### PR DESCRIPTION
deprecation note here: https://crates.io/crates/tempdir