### PR TITLE
Add support for providing partials in data

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use serde::Serialize;
 
 use encoder::Error;
+use crate::Template;
+
 use super::{Data, to_data};
 
 /// `MapBuilder` is a helper type that construct `Data` types.
@@ -148,6 +150,21 @@ impl MapBuilder {
         let MapBuilder { mut data } = self;
         data.insert(key.to_string(), Data::Fun(RefCell::new(Box::new(f))));
         MapBuilder { data: data }
+    }
+
+    /// Adds a template to the `MapBuilder`.
+    /// 
+    /// ```rust
+    /// use mustache::{MapBuilder, compile_str};
+    /// let user_template = compile_str("<strong>{{username}}</strong>").unwrap();
+    /// let data = MapBuilder::new()
+    ///     .insert_template("user", user_template)
+    ///     .build();
+    /// ```
+    #[inline]
+    pub fn insert_template<K: ToString>(mut self, key: K, value: Template) -> MapBuilder {
+        self.data.insert(key.to_string(), Data::Template(value));
+        self
     }
 
     /// Return the built `Data`.

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,12 +5,15 @@ use std::fmt;
 // for bug!
 use log::{log, error};
 
+use crate::Template;
+
 pub enum Data {
     Null,
     String(String),
     Bool(bool),
     Vec(Vec<Data>),
     Map(HashMap<String, Data>),
+    Template(Template),
     Fun(RefCell<Box<dyn FnMut(String) -> String + Send>>),
 }
 
@@ -40,6 +43,7 @@ impl fmt::Debug for Data {
             Data::Bool(v) => write!(f, "Bool({:?})", v),
             Data::Vec(ref v) => write!(f, "VecVal({:?})", v),
             Data::Map(ref v) => write!(f, "Map({:?})", v),
+            Data::Template(ref v) => write!(f, "Template({:?})", v),
             Data::Fun(_) => write!(f, "Fun(...)"),
         }
     }

--- a/tests/template.rs
+++ b/tests/template.rs
@@ -434,6 +434,15 @@ fn assert_partials_data(template: Template) {
     let mut ctx0 = HashMap::new();
     let mut ctx1 = HashMap::new();
     ctx1.insert("name".to_string(), Data::String("a".to_string()));
+    ctx0.insert("names".to_string(), Data::Vec(vec![Data::Map(ctx1)]));
+    let user_partial = compile_str("<span>{{>username}}</span>\n");
+    ctx0.insert("user".to_string(), Data::Template(user_partial));
+    assert_eq!(render_data(&template, &Data::Map(ctx0)),
+                "<h2>Names</h2>\n  <span>a</span>\n\n".to_string());
+
+    let mut ctx0 = HashMap::new();
+    let mut ctx1 = HashMap::new();
+    ctx1.insert("name".to_string(), Data::String("a".to_string()));
     let mut ctx2 = HashMap::new();
     ctx2.insert("name".to_string(), Data::String("<b>".to_string()));
     ctx0.insert("names".to_string(), Data::Vec(vec![Data::Map(ctx1), Data::Map(ctx2)]));


### PR DESCRIPTION
This patch adds `Data::Template`, which allows partials to be provided and/or overridden by the rendered data.  In our case, we need to be able to determine the template for a partial dynamically.  This allows us to do that, as well as provide a "default" partial and replace it at runtime if needed.