### PR TITLE
Update `log` dependency to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0"
 unstable = []
 
 [dependencies]
-log = "0.3.5"
+log = "0.4"
 serde = "1.0.0"
 
 [dev-dependencies]


### PR DESCRIPTION
I have a project that depends on both `mustache` and `log` of version 0.4, but currently `mustache` depends on `log` 0.3, which causes my project to have duplicate `log` dependencies. I hope to unify the `log` dependency of my project, so I hope `mustache` can update its `log` to 0.4.